### PR TITLE
Get the unit tests to pass on Windows

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_free_energy.py
+++ b/python/BioSimSpace/FreeEnergy/_free_energy.py
@@ -31,11 +31,13 @@ __all__ = ["FreeEnergy"]
 from collections import OrderedDict as _OrderedDict
 
 import math as _math
+import sys as _sys
 import os as _os
 import subprocess as _subprocess
 import tempfile as _tempfile
 
 from Sire.Base import getBinDir as _getBinDir
+from Sire.Base import getShareDir as _getShareDir
 
 import Sire.IO as _SireIO
 import Sire.Mol as _SireMol
@@ -53,10 +55,14 @@ class FreeEnergy():
     """Base class for configuring and running free energy simulations."""
 
     # Check that the analyse_freenrg script exists.
-    _analyse_freenrg = _getBinDir() + "/analyse_freenrg"
-
+    if _sys.platform != "win32":
+        _analyse_freenrg = _os.path.join(_getBinDir(), "analyse_freenrg")
+    else:
+        _analyse_freenrg = _os.path.join(_os.path.normpath(_getShareDir()), "scripts", "analyse_freenrg.py")
     if not _os.path.isfile(_analyse_freenrg):
         raise _MissingSoftwareError("Cannot find free energy analysis script in expected location: '%s'" % _analyse_freenrg)
+    if _sys.platform == "win32":
+        _analyse_freenrg = "%s %s" % (_os.path.join(_os.path.normpath(_getBinDir()), "sire_python.exe"), _analyse_freenrg)
 
     # Create a list of supported molecular dynamics engines.
     _engines = ["GROMACS", "SOMD"]

--- a/python/BioSimSpace/Process/_process.py
+++ b/python/BioSimSpace/Process/_process.py
@@ -114,6 +114,9 @@ class Process():
         # Set the process to None.
         self._process = None
 
+        # Set the script to None (used on Windows as it does not support symlinks).
+        self._script = None
+
         # Is the process running interactively? If so, don't block
         # when a get method is called.
         self._is_blocked = not _is_interactive()
@@ -1038,6 +1041,8 @@ class Process():
 
         # Create an empty list.
         args = []
+        if self._script:
+            args.append(self._script)
 
         # Add the arguments to the list.
         for key, value in self._args.items():

--- a/test/Gateway/test_node.py
+++ b/test/Gateway/test_node.py
@@ -14,18 +14,18 @@ exe = sys.executable
 args = ["--bool",
         "--int=42",
         "--float=3.14",
-        "--string='hello'",
+        "--string=\"hello\"",
         "--file=test/io/amber/ala/ala.crd",
         "--fileset=test/io/amber/ala/ala.crd,test/io/amber/ala/ala.top",
-        "--temperature='298 kelvin'",
-        "--time='100 nanoseconds'",
-        "--length='10 angstroms'",
-        "--area='256 nanometers squared'",
-        "--volume='1024 picometers cubed'",
-        "--angle='3.14 radians'",
-        "--charge='-1 electron charge'",
-        "--energy='-1000 kcal/mol'",
-        "--pressure='1 atmosphere'"]
+        "--temperature=\"298 kelvin\"",
+        "--time=\"100 nanoseconds\"",
+        "--length=\"10 angstroms\"",
+        "--area=\"256 nanometers squared\"",
+        "--volume=\"1024 picometers cubed\"",
+        "--angle=\"3.14 radians\"",
+        "--charge=\"-1 electron charge\"",
+        "--energy=\"-1000 kcal/mol\"",
+        "--pressure=\"1 atmosphere\""]
 
 def test_correct_args():
     """Test that correct input from the command line is validated."""


### PR DESCRIPTION
A few changes needed to get the unit tests to pass on Windows.
- The Windows shell does not understand single quotes, only double quotes
- Windows does not support symlinks, so instead of calling the `analyse_freenrg` and `somd` symlinks we need to call `sire_python.exe` and pass the script as first argument