### PR TITLE
Ensure consistent output across different runs with same input

### DIFF
--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -991,8 +991,20 @@ class Molecule(_SireWrapper):
 
             # First create records for the bonds that are unique to lambda = 0 and 1.
 
+            def sort_bonds(bonds, idx):
+                # Get the bond potential.
+                bond = bonds[idx]
+
+                # Get the AtomIdx for the atoms in the bond.
+                idx0 = info.atomIdx(bond.atom0())
+                idx1 = info.atomIdx(bond.atom1())
+                
+                return (mol.atom(idx0).name().value(),
+                        mol.atom(idx1).name().value())
+
             # lambda = 0.
-            for idx in bonds0_unique_idx.values():
+            for idx in sorted(bonds0_unique_idx.values(),
+                              key=lambda idx: sort_bonds(bonds0, idx)):
                 # Get the bond potential.
                 bond = bonds0[idx]
 
@@ -1003,7 +1015,7 @@ class Molecule(_SireWrapper):
                 # Cast the function as an AmberBond.
                 amber_bond = _SireMM.AmberBond(bond.function(), _SireCAS.Symbol("r"))
 
-                # Start angle record.
+                # Start bond record.
                 file.write("    bond\n")
 
                 # Bond data.
@@ -1018,7 +1030,8 @@ class Molecule(_SireWrapper):
                 file.write("    endbond\n")
 
             # lambda = 1.
-            for idx in bonds1_unique_idx.values():
+            for idx in sorted(bonds1_unique_idx.values(),
+                              key=lambda idx: sort_bonds(bonds1, idx)):
                 # Get the bond potential.
                 bond = bonds1[idx]
 
@@ -1029,7 +1042,7 @@ class Molecule(_SireWrapper):
                 # Cast the function as an AmberBond.
                 amber_bond = _SireMM.AmberBond(bond.function(), _SireCAS.Symbol("r"))
 
-                # Start angle record.
+                # Start bond record.
                 file.write("    bond\n")
 
                 # Bond data.
@@ -1044,7 +1057,8 @@ class Molecule(_SireWrapper):
                 file.write("    endbond\n")
 
             # Now add records for the shared bonds.
-            for idx0, idx1 in bonds_shared_idx.values():
+            for idx0, idx1 in sorted(bonds_shared_idx.values(),
+                                     key=lambda idx_pair: sort_bonds(bonds0, idx_pair[0])):
                 # Get the bond potentials.
                 bond0 = bonds0[idx0]
                 bond1 = bonds1[idx1]
@@ -1158,8 +1172,22 @@ class Molecule(_SireWrapper):
 
             # First create records for the angles that are unique to lambda = 0 and 1.
 
+            def sort_angles(angles, idx):
+                # Get the angle potential.
+                angle = angles[idx]
+
+                # Get the AtomIdx for the atoms in the angle.
+                idx0 = info.atomIdx(angle.atom0())
+                idx1 = info.atomIdx(angle.atom1())
+                idx2 = info.atomIdx(angle.atom2())
+                
+                return (mol.atom(idx1).name().value(),
+                        mol.atom(idx0).name().value(),
+                        mol.atom(idx2).name().value())
+
             # lambda = 0.
-            for idx in angles0_unique_idx.values():
+            for idx in sorted(angles0_unique_idx.values(),
+                              key=lambda idx: sort_angles(angles0, idx)):
                 # Get the angle potential.
                 angle = angles0[idx]
 
@@ -1187,7 +1215,8 @@ class Molecule(_SireWrapper):
                 file.write("    endangle\n")
 
             # lambda = 1.
-            for idx in angles1_unique_idx.values():
+            for idx in sorted(angles1_unique_idx.values(),
+                              key=lambda idx: sort_angles(angles1, idx)):
                 # Get the angle potential.
                 angle = angles1[idx]
 
@@ -1215,7 +1244,8 @@ class Molecule(_SireWrapper):
                 file.write("    endangle\n")
 
             # Now add records for the shared angles.
-            for idx0, idx1 in angles_shared_idx.values():
+            for idx0, idx1 in sorted(angles_shared_idx.values(),
+                                     key=lambda idx_pair: sort_angles(angles0, idx_pair[0])):
                 # Get the angle potentials.
                 angle0 = angles0[idx0]
                 angle1 = angles1[idx1]
@@ -1332,8 +1362,24 @@ class Molecule(_SireWrapper):
 
             # First create records for the dihedrals that are unique to lambda = 0 and 1.
 
+            def sort_dihedrals(dihedrals, idx):
+                # Get the dihedral potential.
+                dihedral = dihedrals[idx]
+
+                # Get the AtomIdx for the atoms in the angle.
+                idx0 = info.atomIdx(dihedral.atom0())
+                idx1 = info.atomIdx(dihedral.atom1())
+                idx2 = info.atomIdx(dihedral.atom2())
+                idx3 = info.atomIdx(dihedral.atom3())
+                
+                return (mol.atom(idx1).name().value(),
+                        mol.atom(idx2).name().value(),
+                        mol.atom(idx0).name().value(),
+                        mol.atom(idx3).name().value())
+
             # lambda = 0.
-            for idx in dihedrals0_unique_idx.values():
+            for idx in sorted(dihedrals0_unique_idx.values(),
+                              key=lambda idx: sort_dihedrals(dihedrals0, idx)):
                 # Get the dihedral potential.
                 dihedral = dihedrals0[idx]
 
@@ -1367,7 +1413,8 @@ class Molecule(_SireWrapper):
                 file.write("    enddihedral\n")
 
             # lambda = 1.
-            for idx in dihedrals1_unique_idx.values():
+            for idx in sorted(dihedrals1_unique_idx.values(),
+                              key=lambda idx: sort_dihedrals(dihedrals1, idx)):
                 # Get the dihedral potential.
                 dihedral = dihedrals1[idx]
 
@@ -1401,7 +1448,8 @@ class Molecule(_SireWrapper):
                 file.write("    enddihedral\n")
 
             # Now add records for the shared dihedrals.
-            for idx0, idx1 in dihedrals_shared_idx.values():
+            for idx0, idx1 in sorted(dihedrals_shared_idx.values(),
+                                     key=lambda idx_pair: sort_dihedrals(dihedrals0, idx_pair[0])):
                 # Get the dihedral potentials.
                 dihedral0 = dihedrals0[idx0]
                 dihedral1 = dihedrals1[idx1]

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -393,10 +393,13 @@ class System(_SireWrapper):
         # Otherwise, add the molecules to the existing "all" group.
         else:
             if is_sire_container:
-                try:
-                    molecules = molecules._sire_object.molecules()
-                except:
+                if type(molecules) is _Molecules:
                     molecules = molecules._sire_object
+                else:
+                    try:
+                        molecules = molecules._sire_object.at(_SireMol.MGNum(1))
+                    except:
+                        molecules = molecules._sire_object.molecules()
                 self._sire_object.add(molecules, _SireMol.MGName("all"))
             else:
                 for mol in molecules:


### PR DESCRIPTION
Currently running BioSimSpace multiple times on the same input yields completely different outputs (seen on `prmtop` and `inpcrd` files).
This happens because the Sire `MolGroupsBase::molecules()` method returns molecules by iterating on a `QHash`, so they are not ordered as in the input file, but based on a hash.
Using the `MolGroupsBase::molecules(const MGID &mgid)` method ensures that molecules are output in the same order as in the input.
While this does not change the outcome of a calculation in any way or form, having consistent outputs is important for 1) tidiness 2) spotting out differences/mistakes.

Also sections in the `.pert` file are currently output based on a Python `dict` ordering rather than being consistently sorted based on same criterion. Again, this does not change results but having consistent outputs is important for 1) tidiness 2) spotting out differences/mistakes.