### PR TITLE
Triclinic space support

### DIFF
--- a/doc/source/api/index_Box.rst
+++ b/doc/source/api/index_Box.rst
@@ -1,0 +1,13 @@
+.. _ref-Box:
+
+BioSimSpace.Box
+===================
+
+The *Box* package contains tools for generating parameters for different
+simulation boxes. This is particularly useful when needing box magnitudes and
+angles for generating :ref:`ref-Solvent` boxes.
+
+.. automodule:: BioSimSpace.Box
+
+.. toctree::
+   :maxdepth: 1

--- a/python/BioSimSpace/Box/__init__.py
+++ b/python/BioSimSpace/Box/__init__.py
@@ -1,0 +1,50 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2020
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""
+.. currentmodule:: BioSimSpace.Box
+
+Functions
+=========
+
+.. autosummary::
+    :toctree: generated/
+
+    generateBoxParameters
+    rhombicDodecahedronSquare
+    rhombicDodecahedronHexagon
+    truncatedOctahedron
+    boxTypes
+
+Examples
+========
+
+Generate the lattice vectors and angles for a truncated octahedron
+of 10 nanometer lattice separation.
+
+.. code-block:: python
+
+   import BioSimSpace as BSS
+
+   box, angles = BSS.Box.truncatedOctahedron(10 * BSS.Units.Length.nanometer)
+"""
+
+from ._box import *

--- a/python/BioSimSpace/Box/_box.py
+++ b/python/BioSimSpace/Box/_box.py
@@ -1,0 +1,232 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2020
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""
+Functionality for generating box parameters.
+"""
+
+__author__ = "Lester Hedges"
+__email_ = "lester.hedges@gmail.com"
+
+__all__ = ["boxTypes",
+           "generateBoxParameters",
+           "rhombicDodecahedronSquare",
+           "rhombicDodecahedronHexagon",
+           "truncatedOctahedron"]
+
+from Sire.Maths import Vector as _Vector
+from Sire.Vol import TriclinicBox as _TriclinicBox
+
+from BioSimSpace.Types import Angle as _Angle
+from BioSimSpace.Types import Length as _Length
+
+def generateBoxParameters(box_type, image_distance):
+    """Generate.
+
+       Parameters
+       ----------
+
+       Generate parameters for the named box type with specified image distance.
+
+       box_type : str
+           The name of the box type. Run BioSimSpace.Box.boxTypes() to get a
+           list of the supported boxes.
+
+       image_distance : :class:`Length <BioSimSpace.Types.Length>`
+           The image distance.
+
+       Returns
+       -------
+
+       box : [:class:`Length <BioSimSpace.Types.Length>`]
+           The box vector magnitudes.
+
+       angles : [:class:`Angle <BioSimSpace.Types.Angle>`]
+           The box vector angles: yz, xz, and xy.
+    """
+
+    if type(box_type) is not str:
+        raise TypeError("'box_type' must be of type 'str'")
+    else:
+        # Strip whitespace and convert to lower case.
+        box_type = box_type.replace(" ", "").lower()
+
+        if box_type not in _box_types_lower:
+            raise ValueError("Supported box types are: %s" % boxTypes())
+
+    return _box_type_dict[box_type](image_distance)
+
+def rhombicDodecahedronSquare(image_distance):
+    """Generate parameters for a square rhombic dodecahedron.
+
+       Parameters
+       ----------
+
+       image_distance : :class:`Length <BioSimSpace.Types.Length>`
+           The image distance.
+
+       Returns
+       -------
+
+       box : [:class:`Length <BioSimSpace.Types.Length>`]
+           The box vector magnitudes.
+
+       angles : [:class:`Angle <BioSimSpace.Types.Angle>`]
+           The box vector angles: yz, xz, and xy.
+    """
+
+
+    # Validate arguments.
+
+    if type(image_distance) is not _Length:
+        raise TypeError("'image_distance' must be of type 'BioSimSpace.Types.Length'.")
+
+    if image_distance.magnitude() <=0:
+        raise ValueError("'image_distance' must be greater than zero.")
+
+    # Create the triclinic box.
+
+    triclinic_box = _TriclinicBox.rhombicDodecahedronSquare(image_distance.angstroms().magnitude())
+
+    return _get_box_parameters(triclinic_box)
+
+def rhombicDodecahedronHexagon(image_distance):
+    """Generate parameters for a hexagonal rhombic dodecahedron.
+
+       Parameters
+       ----------
+
+       image_distance : :class:`Length <BioSimSpace.Types.Length>`
+           The image distance.
+
+       Returns
+       -------
+
+       box : [:class:`Length <BioSimSpace.Types.Length>`]
+           The box vector magnitudes.
+
+       angles : [:class:`Angle <BioSimSpace.Types.Angle>`]
+           The box vector angles: yz, xz, and xy.
+    """
+
+
+    # Validate arguments.
+
+    if type(image_distance) is not _Length:
+        raise TypeError("'image_distance' must be of type 'BioSimSpace.Types.Length'.")
+
+    if image_distance.magnitude() <=0:
+        raise ValueError("'image_distance' must be greater than zero.")
+
+    # Create the triclinic box.
+
+    triclinic_box = _TriclinicBox.rhombicDodecahedronHexagon(image_distance.angstroms().magnitude())
+
+    return _get_box_parameters(triclinic_box)
+
+def truncatedOctahedron(image_distance):
+    """Generate parameters for a truncated octahedron.
+
+       Parameters
+       ----------
+
+       image_distance : :class:`Length <BioSimSpace.Types.Length>`
+           The image distance.
+
+       Returns
+       -------
+
+       box : [:class:`Length <BioSimSpace.Types.Length>`]
+           The box vector magnitudes.
+
+       angles : [:class:`Angle <BioSimSpace.Types.Angle>`]
+           The box vector angles: yz, xz, and xy.
+    """
+
+
+    # Validate arguments.
+
+    if type(image_distance) is not _Length:
+        raise TypeError("'image_distance' must be of type 'BioSimSpace.Types.Length'.")
+
+    if image_distance.magnitude() <=0:
+        raise ValueError("'image_distance' must be greater than zero.")
+
+    # Create the triclinic box.
+
+    triclinic_box = _TriclinicBox.truncatedOctahedron(image_distance.angstroms().magnitude())
+
+    return _get_box_parameters(triclinic_box)
+
+
+
+def _get_box_parameters(triclinic_box):
+    """Internal helper function to get paramters for the passed triclinic box.
+
+       Parameters
+       ----------
+
+       triclinic_box : :class `TriclinicBox <Sire.Vol.TriclinicBox>`
+
+       Returns
+       -------
+
+       box : [:class:`Length <BioSimSpace.Types.Length>`]
+           The box vector magnitudes.
+    """
+
+    box = [_Length(triclinic_box.vector0().magnitude(), "angstrom"),
+           _Length(triclinic_box.vector1().magnitude(), "angstrom"),
+           _Length(triclinic_box.vector2().magnitude(), "angstrom")]
+
+    angles = [_Angle(_Vector.angle(triclinic_box.vector1(), triclinic_box.vector2()).value(), "radians").degrees(),
+              _Angle(_Vector.angle(triclinic_box.vector0(), triclinic_box.vector2()).value(), "radians").degrees(),
+              _Angle(_Vector.angle(triclinic_box.vector0(), triclinic_box.vector1()).value(), "radians").degrees()]
+
+    return box, angles
+
+
+# Create a list of the box type names.
+# This needs to come after all of the box functions.
+_box_types = []         # List of box types (actual names).
+_box_types_lower = []   # List of lower case names.
+_box_types_dict = {}    # Mapping between lower case names and functions.
+import sys as _sys
+_namespace = _sys.modules[__name__]
+for _var in dir():
+    if _var[0] != "_" and _var[0].upper() != "G":
+        _box_types.append(_var)
+        _box_types_lower.append(_var.lower())
+        _box_types_dict[_var.lower()] = getattr(_namespace, _var)
+del _namespace
+del _sys
+del _var
+
+def boxTypes():
+    """Return a list of the supported box types.
+
+       Returns
+       -------
+
+       box_types_fields : [str]
+           A list of the supported box types.
+    """
+    return _box_types

--- a/python/BioSimSpace/Box/_box.py
+++ b/python/BioSimSpace/Box/_box.py
@@ -176,8 +176,6 @@ def truncatedOctahedron(image_distance):
 
     return _get_box_parameters(triclinic_box)
 
-
-
 def _get_box_parameters(triclinic_box):
     """Internal helper function to get paramters for the passed triclinic box.
 
@@ -202,7 +200,6 @@ def _get_box_parameters(triclinic_box):
               _Angle(_Vector.angle(triclinic_box.vector0(), triclinic_box.vector1()).value(), "radians").degrees()]
 
     return box, angles
-
 
 # Create a list of the box type names.
 # This needs to come after all of the box functions.

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -2002,7 +2002,7 @@ class Gromacs(_process.Process):
                 old_system = self._system.copy()
                 old_system._updateCoordinates(new_system)
 
-                # Update the periodic box information in the original system.
+                # Update the box information in the original system.
                 try:
                     box = new_system._sire_object.property("space")
                     old_system._sire_object.setProperty(self._property_map.get("space", "space"), box)

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -825,7 +825,7 @@ class Gromacs(_process.Process):
 
         try:
             # Locate the trajectory file.
-            traj_file = _find_trajectory_file()
+            traj_file = self._find_trajectory_file()
 
             if traj_file is None:
                 return None
@@ -1977,7 +1977,7 @@ class Gromacs(_process.Process):
             with _Utils.cd(self._work_dir):
 
                 # Locate the trajectory file.
-                traj_file = _find_trajectory_file()
+                traj_file = self._find_trajectory_file()
 
                 if traj_file is None:
                     return None
@@ -2040,13 +2040,13 @@ class Gromacs(_process.Process):
 
             # Only accept if a single trajectory file is present.
             if num_trr == 1:
-                traj_file = traj_file[0]
+                return traj_file[0]
             else:
                 # Now check for any xtc files.
                 traj_file = _IO.glob("%s/*.xtc" % self._work_dir)
 
                 if len(traj_file) == 1:
-                    traj_file = traj_file[0]
+                    return traj_file[0]
                 else:
                     _warnings.warn("Invalid trajectory file! "
                                    "%d trr files found, %d xtc files found."

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -645,7 +645,7 @@ class Somd(_process.Process):
             old_system = self._system.copy()
             old_system._updateCoordinates(new_system)
 
-            # Update the periodic box information in the original system.
+            # Update the box information in the original system.
             if "space" in new_system._sire_object.propertyKeys():
                 box = new_system._sire_object.property("space")
                 old_system._sire_object.setProperty(self._property_map.get("space", "space"), box)

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -46,13 +46,14 @@ from BioSimSpace._SireWrappers import System as _System
 from BioSimSpace._SireWrappers import Molecule as _Molecule
 from BioSimSpace._SireWrappers import Molecules as _Molecules
 from BioSimSpace.Types import Coordinate as _Coordinate
+from BioSimSpace.Types import Angle as _Angle
 from BioSimSpace.Types import Length as _Length
 
 from BioSimSpace import IO as _IO
 from BioSimSpace import _Utils as _Utils
 
-def solvate(model, molecule=None, box=None, shell=None,
-        ion_conc=0, is_neutral=True, work_dir=None, property_map={}):
+def solvate(model, molecule=None, box=None, angles=3*[_Angle(90, "degrees")],
+        shell=None, ion_conc=0, is_neutral=True, work_dir=None, property_map={}):
     """Add SPC solvent.
 
        Parameters
@@ -67,7 +68,10 @@ def solvate(model, molecule=None, box=None, shell=None,
            A molecule, or container/system of molecules.
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
-           A list containing the box size in each dimension.
+           A list containing the box size in each dimension: x, y, and z.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute. Note that the
@@ -106,10 +110,10 @@ def solvate(model, molecule=None, box=None, shell=None,
         if model not in _models_lower:
             raise ValueError("Supported water models are: %s" % waterModels())
 
-    return _model_dict[model](molecule, box, shell, ion_conc, is_neutral, work_dir, property_map)
+    return _model_dict[model](molecule, box, angles, shell, ion_conc, is_neutral, work_dir, property_map)
 
-def spc(molecule=None, box=None, shell=None, ion_conc=0,
-        is_neutral=True, work_dir=None, property_map={}):
+def spc(molecule=None, box=None, angles=3*[_Angle(90, "degrees")],
+        shell=None, ion_conc=0, is_neutral=True, work_dir=None, property_map={}):
     """Add SPC solvent.
 
        Parameters
@@ -122,6 +126,9 @@ def spc(molecule=None, box=None, shell=None, ion_conc=0,
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
            A list containing the box size in each dimension.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute. Note that the
@@ -155,15 +162,15 @@ def spc(molecule=None, box=None, shell=None, ion_conc=0,
                                     "Please install GROMACS (http://www.gromacs.org).")
 
     # Validate arguments.
-    molecule, box, shell, work_dir, property_map = \
-        _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, property_map)
+    molecule, box, angles, shell, work_dir, property_map = \
+        _validate_input(molecule, box, angles, shell, ion_conc, is_neutral, work_dir, property_map)
 
     # Create the solvated system.
-    return _solvate(molecule, box, shell, "spc", 3, ion_conc,
+    return _solvate(molecule, box, angles, shell, "spc", 3, ion_conc,
             is_neutral, work_dir=work_dir, property_map=property_map)
 
-def spce(molecule=None, box=None, shell=None, ion_conc=0, is_neutral=True,
-        work_dir=None, property_map={}):
+def spce(molecule=None, box=None, angles=3*[_Angle(90, "degrees")],
+        shell=None, ion_conc=0, is_neutral=True, work_dir=None, property_map={}):
     """Add SPC/E solvent.
 
        Parameters
@@ -176,6 +183,9 @@ def spce(molecule=None, box=None, shell=None, ion_conc=0, is_neutral=True,
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
            A list containing the box size in each dimension.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute. Note that the
@@ -209,15 +219,15 @@ def spce(molecule=None, box=None, shell=None, ion_conc=0, is_neutral=True,
                                     "Please install GROMACS (http://www.gromacs.org).")
 
     # Validate arguments.
-    molecule, box, shell, work_dir, property_map = \
-        _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, property_map)
+    molecule, box, angles, shell, work_dir, property_map = \
+        _validate_input(molecule, box, angles, shell, ion_conc, is_neutral, work_dir, property_map)
 
     # Create the solvated system.
-    return _solvate(molecule, box, shell, "spce", 3, ion_conc,
+    return _solvate(molecule, box, angles, shell, "spce", 3, ion_conc,
             is_neutral, work_dir=work_dir, property_map=property_map)
 
-def tip3p(molecule=None, box=None, shell=None, ion_conc=0,
-        is_neutral=True, work_dir=None, property_map={}):
+def tip3p(molecule=None, box=None, angles=3*[_Angle(90, "degrees")],
+        shell=None, ion_conc=0, is_neutral=True, work_dir=None, property_map={}):
     """Add TIP3P solvent.
 
        Parameters
@@ -230,6 +240,9 @@ def tip3p(molecule=None, box=None, shell=None, ion_conc=0,
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
            A list containing the box size in each dimension.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute. Note that the
@@ -263,15 +276,15 @@ def tip3p(molecule=None, box=None, shell=None, ion_conc=0,
                                     "Please install GROMACS (http://www.gromacs.org).")
 
     # Validate arguments.
-    molecule, box, shell, work_dir, property_map = \
-        _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, property_map)
+    molecule, box, angles, shell, work_dir, property_map = \
+        _validate_input(molecule, box, angles, shell, ion_conc, is_neutral, work_dir, property_map)
 
     # Create the solvated system.
-    return _solvate(molecule, box, shell, "tip3p", 3, ion_conc,
+    return _solvate(molecule, box, angles, shell, "tip3p", 3, ion_conc,
             is_neutral, work_dir=work_dir, property_map=property_map)
 
-def tip4p(molecule=None, box=None, shell=None, ion_conc=0,
-        is_neutral=True, work_dir=None, property_map={}):
+def tip4p(molecule=None, box=None, angles=3*[_Angle(90, "degrees")],
+        shell=None, ion_conc=0, is_neutral=True, work_dir=None, property_map={}):
     """Add TIP4P solvent.
 
        Parameters
@@ -284,6 +297,9 @@ def tip4p(molecule=None, box=None, shell=None, ion_conc=0,
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
            A list containing the box size in each dimension.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute. Note that the
@@ -317,15 +333,15 @@ def tip4p(molecule=None, box=None, shell=None, ion_conc=0,
                                     "Please install GROMACS (http://www.gromacs.org).")
 
     # Validate arguments.
-    molecule, box, shell, work_dir, property_map = \
-        _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, property_map)
+    molecule, box, angles, shell, work_dir, property_map = \
+        _validate_input(molecule, box, angles, shell, ion_conc, is_neutral, work_dir, property_map)
 
     # Return the solvated system.
-    return _solvate(molecule, box, shell, "tip4p", 4, ion_conc,
+    return _solvate(molecule, box, angles, shell, "tip4p", 4, ion_conc,
             is_neutral, work_dir=work_dir, property_map=property_map)
 
-def tip5p(molecule=None, box=None, shell=None, ion_conc=0,
-        is_neutral=True, work_dir=None, property_map={}):
+def tip5p(molecule=None, box=None, angles=3*[_Angle(90, "degrees")],
+        shell=None, ion_conc=0, is_neutral=True, work_dir=None, property_map={}):
     """Add TIP5P solvent.
 
        Parameters
@@ -338,6 +354,9 @@ def tip5p(molecule=None, box=None, shell=None, ion_conc=0,
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
            A list containing the box size in each dimension.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute. Note that the
@@ -371,14 +390,14 @@ def tip5p(molecule=None, box=None, shell=None, ion_conc=0,
                                     "Please install GROMACS (http://www.gromacs.org).")
 
     # Validate arguments.
-    molecule, box, shell, work_dir, property_map = \
-        _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, property_map)
+    molecule, box, angles, shell, work_dir, property_map = \
+        _validate_input(molecule, box, angles, shell, ion_conc, is_neutral, work_dir, property_map)
 
     # Return the solvated system.
-    return _solvate(molecule, box, shell, "tip5p", 5, ion_conc,
+    return _solvate(molecule, box, angles, shell, "tip5p", 5, ion_conc,
             is_neutral, work_dir=work_dir, property_map=property_map)
 
-def _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, property_map):
+def _validate_input(molecule, box, angles, shell, ion_conc, is_neutral, work_dir, property_map):
     """Internal function to validate function arguments.
 
        Parameters
@@ -391,6 +410,9 @@ def _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, proper
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
            A list containing the box size in each dimension.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute. Note that the
@@ -415,7 +437,7 @@ def _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, proper
        Returns
        -------
 
-       (molecule, box, shell, work_dir, property_map) : tuple
+       (molecule, box, angles, shell, work_dir, property_map) : tuple
            The validated input arguments.
     """
 
@@ -474,6 +496,20 @@ def _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, proper
         else:
             if not all(isinstance(x, _Length) for x in box):
                 raise ValueError("The box dimensions must be of type 'BioSimSpace.Types.Length'")
+            if not all(x.magnitude() >= 0 for x in box):
+                raise ValueError("All box dimensions must be greater than zero.")
+
+    if angles is not None:
+        # Convert tuple to list.
+        if type(angles) is tuple:
+            angles = list(angles)
+
+        # Validate.
+        if len(angles) != 3:
+            raise ValueError("'angles' must have three components: yz, xz, and xy.")
+        else:
+            if not all(isinstance(x, _Angle) for x in angles):
+                raise ValueError("The angle between box vectors must be of type 'BioSimSpace.Types.Angle'")
 
     if shell is not None:
         if type(shell) is not _Length:
@@ -519,9 +555,9 @@ def _validate_input(molecule, box, shell, ion_conc, is_neutral, work_dir, proper
         if molecule is not None and shell is None and not _check_box_size(molecule, box, property_map):
             raise ValueError("The 'box' is not large enough to hold the 'molecule'")
 
-    return (_molecule, box, shell, work_dir, property_map)
+    return (_molecule, box, angles, shell, work_dir, property_map)
 
-def _solvate(molecule, box, shell, model, num_point,
+def _solvate(molecule, box, angles, shell, model, num_point,
         ion_conc, is_neutral, work_dir=None, property_map={}):
     """Internal function to add solvent using 'gmx solvate'.
 
@@ -534,6 +570,9 @@ def _solvate(molecule, box, shell, model, num_point,
 
        box : [:class:`Length <BioSimSpace.Types.Length>`]
            A list containing the box size in each dimension.
+
+       angles : [:class:`Length <BioSimSpace.Types.Angle>`]
+           A list containing the angles between the box vectors: yz, xz, and xy.
 
        shell : :class:`Length` <BioSimSpace.Types.Length>`
            Thickness of the water shell around the solute.
@@ -567,19 +606,6 @@ def _solvate(molecule, box, shell, model, num_point,
     """
 
     if molecule is not None:
-        # Store the centre of the molecule.
-        center = molecule._getAABox(property_map).center()
-
-        # Work out the vector from the centre of the molecule to the centre of the
-        # water box, converting the distance in each direction to Angstroms.
-        vec = []
-        for x, y in zip(box, center):
-            vec.append(0.5*x.angstroms().magnitude() - y)
-
-        # Translate the molecule. This allows us to create a water box
-        # around the molecule.
-        molecule.translate(vec, property_map)
-
         if type(molecule) is _System:
 
             # Reformat all of the water molecules so that they match the
@@ -601,39 +627,54 @@ def _solvate(molecule, box, shell, model, num_point,
     # Run the solvation in the working directory.
     with _Utils.cd(work_dir):
 
-        # Create the gmx command.
-        if num_point == 3:
-            mod = "spc216"
-        else:
-            mod = model
-        command = "%s solvate -cs %s" % (_gmx_exe, mod)
-
+        # First, generate a box file corresponding to the requested geometry.
         if molecule is not None:
             # Write the molecule/system to a GRO files.
             _IO.saveMolecules("input", molecule, "gro87")
             _os.rename("input.gro87", "input.gro")
 
-            # Update the command.
-            command += " -cp input.gro"
-
-            # Add the box information.
-            if box is not None:
-                command += " -box %f %f %f" % (box[0].nanometers().magnitude(),
-                                               box[1].nanometers().magnitude(),
-                                               box[2].nanometers().magnitude())
-
             # Add the shell information.
             if shell is not None:
                 command += " -shell %f" % shell.nanometers().magnitude()
 
-        # Just add box information.
+        # We need to create a dummy input file with no molecule in it.
         else:
-            command += " -box %f %f %f" % (box[0].nanometers().magnitude(),
-                                           box[1].nanometers().magnitude(),
-                                           box[2].nanometers().magnitude())
+            with open("input.gro", "w") as file:
+                f.write("BioSimSpace System\n")
+                f.write("    0\n")
+                f.write("   0.00000  0.00000  0.00000\n")
 
-        # Add the output file.
-        command += " -o output.gro"
+        # Create the editconf command.
+        command = "%s editconf -f input.gro -bt triclinic" % _gmx_exe    \
+                + " -box %f %f %f" % (box[0].nanometers().magnitude(),
+                                      box[1].nanometers().magnitude(),
+                                      box[2].nanometers().magnitude())   \
+                + " -angles %f %f %f" % (angles[0].degrees().magnitude(),
+                                         angles[1].degrees().magnitude(),
+                                         angles[2].degrees().magnitude()) \
+                + " -o box.gro"
+
+        # Create files for stdout/stderr.
+        stdout = open("editconf.out", "w")
+        stderr = open("editconf.err", "w")
+
+        # Run gmx solvate as a subprocess.
+        proc = _subprocess.run(command, shell=True, stdout=stdout, stderr=stderr)
+        stdout.close()
+        stderr.close()
+
+        # gmx doesn't return sensible error codes, so we need to check that
+        # the expected output was generated.
+        if not _os.path.isfile("box.gro"):
+            raise RuntimeError("'gmx editconf failed to generate required box! " +
+                               "Check your lattice vectors and angles.")
+
+        # Create the gmx command.
+        if num_point == 3:
+            mod = "spc216"
+        else:
+            mod = model
+        command = "%s solvate -cs %s -cp box.gro -o output.gro" % (_gmx_exe, mod)
 
         with open("README.txt", "w") as file:
             # Write the command to file.
@@ -698,11 +739,6 @@ def _solvate(molecule, box, shell, model, num_point,
 
         # Create a new system by adding the water to the original molecule.
         if molecule is not None:
-            # Translate the molecule and water back to the original position.
-            vec = [-x for x in vec]
-            molecule.translate(vec, property_map)
-            water.translate(vec)
-
             if type(molecule) is _System:
                 # Extract the non-water molecules from the original system.
                 non_waters = _Molecules(molecule.search("not water")._sire_object.toMolecules())

--- a/python/BioSimSpace/Solvent/_solvent.py
+++ b/python/BioSimSpace/Solvent/_solvent.py
@@ -510,6 +510,9 @@ def _validate_input(molecule, box, angles, shell, ion_conc, is_neutral, work_dir
         else:
             if not all(isinstance(x, _Angle) for x in angles):
                 raise ValueError("The angle between box vectors must be of type 'BioSimSpace.Types.Angle'")
+    else:
+        # Default to periodic box.
+        angles=3*[_Angle(90, "degrees")]
 
     if shell is not None:
         if type(shell) is not _Length:

--- a/python/BioSimSpace/__init__.py
+++ b/python/BioSimSpace/__init__.py
@@ -32,6 +32,7 @@ __author__ = "Lester Hedges"
 __email_ = "lester.hedges@gmail.com"
 
 __all__ = ["Align",
+           "Box",
            "FreeEnergy",
            "Gateway",
            "IO",
@@ -179,6 +180,7 @@ if not _path.isdir(_gromacs_path):
         del _subprocess
 
 from . import Align
+from . import Box
 from . import FreeEnergy
 from . import Gateway
 from . import IO

--- a/test/Process/test_single_point_energy.py
+++ b/test/Process/test_single_point_energy.py
@@ -61,3 +61,54 @@ def test_amber_gromacs():
     nrg_amb = process_amb.getDihedralEnergy().kj_per_mol().magnitude()
     nrg_gmx = process_gmx.getDihedralEnergy().kj_per_mol().magnitude()
     assert nrg_amb == pytest.approx(nrg_gmx, rel=1e-2)
+
+@pytest.mark.skipif(has_amber is False or has_gromacs is False,
+    reason="Requires that both AMBER and GROMACS are installed.")
+def test_amber_gromacs_triclinic():
+    """Single point energy comparison between AMBER and GROMACS in a triclinic box."""
+
+    # Load the vacuum ubiquitin system.
+    files = BSS.IO.glob("test/io/amber/ubiquitin/*")
+    system = BSS.IO.readMolecules(files)
+
+    # Swap the space for a triclinic cell (truncated octahedron).
+    from Sire.Vol import TriclinicBox
+    triclinic_box = TriclinicBox.truncatedOctahedron(50)
+    system._sire_object.setProperty("space", triclinic_box)
+
+    # Create a single-step minimisation protocol.
+    protocol = BSS.Protocol.Minimisation(steps=1)
+
+    # Create a process to run with AMBER.
+    process_amb = BSS.Process.Amber(system, protocol)
+
+    # Create a process to run with GROMACS.
+    process_gmx = BSS.Process.Gromacs(system, protocol)
+
+    # Modify the GROMACS configuration to run zero steps.
+    config = process_gmx.getConfig()
+    config[1] = "nsteps = 0"
+    process_gmx.setConfig(config)
+
+    # Run the AMBER process and wait for it to finish.
+    process_amb.start()
+    process_amb.wait()
+
+    # Run the GROMACS process and wait for it to finish.
+    process_gmx.start()
+    process_gmx.wait()
+
+    # Compare bond energies. (In kJ / mol)
+    nrg_amb = process_amb.getBondEnergy().kj_per_mol().magnitude()
+    nrg_gmx = process_gmx.getBondEnergy().kj_per_mol().magnitude()
+    assert nrg_amb == pytest.approx(nrg_gmx, rel=1e-2)
+
+    # Compare angle energies. (In kJ / mol)
+    nrg_amb = process_amb.getAngleEnergy().kj_per_mol().magnitude()
+    nrg_gmx = process_gmx.getAngleEnergy().kj_per_mol().magnitude()
+    assert nrg_amb == pytest.approx(nrg_gmx, rel=1e-2)
+
+    # Compare dihedral energies. (In kJ / mol)
+    nrg_amb = process_amb.getDihedralEnergy().kj_per_mol().magnitude()
+    nrg_gmx = process_gmx.getDihedralEnergy().kj_per_mol().magnitude()
+    assert nrg_amb == pytest.approx(nrg_gmx, rel=1e-2)


### PR DESCRIPTION
Building from [this](https://github.com/michellab/Sire/pull/325) Sire pull request, I have updated BioSimSpace to provide support for triclinic simulation boxes. A quick summary is as follows:

* Added functionality for generating triclinic solvent boxes using `gmx editconf` and `gmx solvate`.
* New `BioSimSpace.Box` package for generating triclinic box parameters. (These can be used to create solvent boxes, or can be passed to `FreeEnergy.Binding` to create a custom box for the free leg.
* Updated `BioSimSpace.Process.Namd` to generate configuration files for triclinic simulation boxes. (AMBER and GROMACS handle triclinic cells automatically through the coordinate files.)
* Added single-point energy test for AMBER/GROMACS using a triclinic simulation box.

(Note that this pull request can only be merged after the corresponding [Sire pull request](https://github.com/michellab/Sire/pull/325) has been accepted.)