### PR TITLE
Add support for exporting CWL wrappers from BioSimSpace nodes

### DIFF
--- a/doc/source/nodes.rst
+++ b/doc/source/nodes.rst
@@ -159,6 +159,17 @@ Here ``config.yaml`` is a YAML configuration file, e.g.:
     steps:
     1000
 
+At present, using BioSimSpace within CWL is limited to the use of
+:class:`BioSimSpace.Gateway.File <BioSimSpace.Gateway.File>`
+and
+:class:`BioSimSpace.Gateway.FileSet <BioSimSpace.Gateway.FileSet>`
+requirements, which cover the majority of use cases. Due to the way in which
+CWL works, the prefix used for output files must match the name used for the
+requirement, e.g. if a requirement was called ``output``, then a file might be
+named ``output.txt``. This allows the use of ``glob`` in the CWL ``outputBinding``
+functionality. This requirement is automatically enforced so that files will
+be renamed when a mismatch is found.
+
 Forwards compatibility
 ======================
 

--- a/doc/source/nodes.rst
+++ b/doc/source/nodes.rst
@@ -134,9 +134,9 @@ function.)
 Common Workflow Language
 ========================
 
-It is also possible to export a node as a Common Workflow Language
-`(CFL) <https://www.commonwl.org/>`__ wrapper. For example, using the
-``minimisation.py`` example from the previous section:
+It is also possible to export a node as a
+`Common Workflow Language <https://www.commonwl.org/>`__ (CWL) wrapper.
+For example, using the ``minimisation.py`` example from the previous section:
 
 .. code-block:: bash
 

--- a/doc/source/nodes.rst
+++ b/doc/source/nodes.rst
@@ -155,11 +155,11 @@ Here ``config.yaml`` is a YAML configuration file, e.g.:
 .. code-block:: yaml
 
     files:
-    - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.top}
-    - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.crd}
+      - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.top}
+      - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.crd}
 
     steps:
-    1000
+      1000
 
 At present, using BioSimSpace within CWL is limited to the use of
 :class:`BioSimSpace.Gateway.File <BioSimSpace.Gateway.File>`
@@ -179,7 +179,7 @@ specifing as a CWL ``string`` type to allow for greatest flexibility, e.g.:
 .. code-block:: yaml
 
     length:
-    25 Angstroms
+      25 Angstroms
 
 Forwards compatibility
 ======================

--- a/doc/source/nodes.rst
+++ b/doc/source/nodes.rst
@@ -142,6 +142,8 @@ It is also possible to export a node as a Common Workflow Language
 
     python minimisation.py --export-cwl
 
+This will write a wrapper called ``minimisation.cwl`` to the current directory.
+
 The node could then be run as part of a CWL workflow using something like:
 
 .. code-block:: bash

--- a/doc/source/nodes.rst
+++ b/doc/source/nodes.rst
@@ -170,6 +170,15 @@ named ``output.txt``. This allows the use of ``glob`` in the CWL ``outputBinding
 functionality. This requirement is automatically enforced so that files will
 be renamed when a mismatch is found.
 
+Any unit based input requirement, e.g.
+:class:`BioSimSpace.Gateway.Length <BioSimSpace.Gateway.Length>`, should be
+specifing as a CWL ``string`` type to allow for greatest flexibility, e.g.:
+
+.. code-block:: yaml
+
+    length:
+    25 Angstroms
+
 Forwards compatibility
 ======================
 

--- a/doc/source/nodes.rst
+++ b/doc/source/nodes.rst
@@ -108,7 +108,7 @@ input to another. For example, given the following YAML configuration file,
 
 it would be possible to run a minimisation followed by an equilibration as follows:
 
-.. code-block:: python
+.. code-block:: bash
 
     python minimisation.py --config config.yaml && python equilibration.py --config output.yaml
 
@@ -130,6 +130,34 @@ directory wherever BioSimSpace is installed, e.g.
 set a custom directory, use the
 :class:`BioSimSpace.Node.setNodeDirectory <BioSimSpace.Node.setNodeDirectory>`
 function.)
+
+Common Workflow Language
+========================
+
+It is also possible to export a node as a Common Workflow Language
+`(CFL) <https://www.commonwl.org/>`__ wrapper. For example, using the
+``minimisation.py`` example from the previous section:
+
+.. code-block:: bash
+
+    python minimisation.py --export-cwl
+
+The node could then be run as part of a CWL workflow using something like:
+
+.. code-block:: bash
+
+    cwltool minimisation.cwl config.yaml
+
+Here ``config.yaml`` is a YAML configuration file, e.g.:
+
+.. code-block:: yaml
+
+    files:
+    - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.top}
+    - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.crd}
+
+    steps:
+    1000
 
 Forwards compatibility
 ======================

--- a/python/BioSimSpace/Gateway/_node.py
+++ b/python/BioSimSpace/Gateway/_node.py
@@ -32,6 +32,7 @@ import configargparse as _argparse
 import collections as _collections
 import __main__
 import os as _os
+import shutil as _shutil
 import sys as _sys
 import textwrap as _textwrap
 import warnings as _warnings
@@ -82,9 +83,12 @@ class CwlAction(_argparse.Action):
         cls.inputs = node._inputs
         cls.outputs = node._outputs
 
-
     def __call__(self, parser, namespace, values, option_string=None):
         """Export the CWL wrapper."""
+
+        if values == False:
+            parser.exit()
+            return
 
         for value in self.outputs.values():
             # Currently we only support File and FileSet output
@@ -109,7 +113,7 @@ class CwlAction(_argparse.Action):
             # Write the header.
             file.write( "cwlVersion: v1.0\n")
             file.write( "class: CommandLineTool\n")
-            file.write(f'baseCommand: ["{exe}", "{node}"]\n')
+            file.write(f'baseCommand: ["{exe}", "{node}", "--strict-file-naming"]\n')
 
             # Write the inputs section.
             file.write("\n")
@@ -298,6 +302,9 @@ class Node():
         # Intialise the Jupyter input panel.
         self._control_panel = None
 
+        # Strict file naming is off by default.
+        self._strict_file_naming = False
+
         # Running from the command-line.
         if not self._is_knime and not self._is_notebook:
             # Generate the node help description.
@@ -316,11 +323,13 @@ class Node():
             self._required = self._parser.add_argument_group("Required arguments")
             self._optional = self._parser.add_argument_group("Optional arguments")
             self._optional.add_argument("-h", "--help", action="help", help="Show this help message and exit.")
-            self._optional.add_argument("--export-cwl", action=CwlAction, nargs=0,
-                                        help="Export Common Workflow Language (CWL) wrapper and exit.")
             self._optional.add_argument("-c", "--config", is_config_file=True, help="Path to configuration file.")
             self._optional.add_argument("-v", "--verbose", type=_str2bool, nargs='?', const=True, default=False,
                                         help="Print verbose error messages.")
+            self._optional.add_argument("--export-cwl", action=CwlAction, type=_str2bool, nargs='?', const=True,
+                                        default=False, help="Export Common Workflow Language (CWL) wrapper and exit.")
+            self._optional.add_argument("--strict-file-naming", type=_str2bool, nargs='?', const=True, default=False,
+                                        help="Enforce that the prefix of any file based output matches its name.")
 
             # Overload the "_check_value" method for more flexible string support.
             # (Ignore whitespace and case insensitive.)
@@ -850,6 +859,44 @@ class Node():
                The value of the output.
         """
         try:
+            # Enforce strict naming for all file-based outputs. This ensures
+            # that the prefix used matches the requirement name.
+            if self._strict_file_naming:
+                if type(self._outputs[name]) in [_File, _FileSet]:
+                    is_file = False
+                    new_value = []
+                    # For convenience, convert single file names to a list with
+                    # one entry.
+                    if type(value) == str:
+                        value = [value]
+                        is_file = True
+                    # Loop over each file.
+                    for file in value:
+                        # Get the directory name, file prefix, and file extension.
+                        basename = _os.path.basename(file)
+                        dirname = _os.path.dirname(file)
+                        fileprefix = basename.split(".")[0]
+                        extension = basename.split(".")[1]
+
+                        # If the file prefix doesn't match the requirement name, then
+                        # rename, i.e. move, the file.
+                        if fileprefix != name:
+                            _warnings.warn(f"Output file prefix '{fileprefix}' "
+                                           f"doesn't match requirement name '{name}'. "
+                                            "Renaming file!")
+                            new_name = dirname + f"/{name}.{extension}"
+                            _shutil.move(file, new_name)
+                            file = new_name
+
+                        # Store the new value of the file name.
+                        new_value.append(file)
+
+                    # Convert back into a single entry if this was a File requirement.
+                    if is_file:
+                        value = new_value[0]
+                    else:
+                        value = new_value
+
             self._outputs[name].setValue(value, name=name)
         except KeyError:
             raise
@@ -1113,6 +1160,9 @@ class Node():
             for key, value in args.items():
                 if key is "verbose":
                     setVerbose(value)
+                elif key is "strict_file_naming":
+                    if value is True:
+                        self._strict_file_naming = True
                 else:
                     if not key in ["config", "export_cwl"]:
                         self._inputs[key].setValue(value, name=key)

--- a/python/BioSimSpace/Gateway/_requirements.py
+++ b/python/BioSimSpace/Gateway/_requirements.py
@@ -177,7 +177,7 @@ class Requirement():
 
         # Maximum.
         if self._max is not None and value > self._max:
-            raise ValueError("The value (%s) is less than the allowed "
+            raise ValueError("The value (%s) is greater than the allowed "
                 "maximum (%s)" % (value, self._max))
 
         # Allowed values.


### PR DESCRIPTION
This pull request adds functionality to export [Common Workflow Language](https://www.commonwl.org/) (CWL) wrappers from a BioSimSpace node, for example:

```python
python minimisation.py --export-cwl
```

This writes a wrapper called `minimisation.cwl` in the current directory, which can be run as part of CWL workflow as follows:

```bash
cwltool minimisation.cwl config.yaml
```

Depending on your setup, you might need to run:

```bash
cwltool --preserve-entire-environment minimisation.cwl config.yaml
```


Here `config.yaml` is a CWL YAML configuration file, e.g.:

```yaml
files:
   - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.top}
   - {class: File, path: /home/lester/BioSimSpace/demo/amber/ala/ala.crd}

steps:
  1000
```

At present, using BioSimSpace within CWL is limited to the use of `BioSimSpace.Gateway.File` and `BioSimSpace.Gateway.FileSet` output requirements, which cover the majority of use cases. Due to the way in which CWL works, the prefix used for output files must match the name used for the requirement, e.g. if a requirement was called `output`, then a file might be named `output.txt`. This allows the use of `glob` in the CWL `outputBinding` functionality. This requirement is automatically enforced so that files will be renamed when a mismatch is found.

Any unit based input requirement, e.g. `BioSimSpace.Gateway.Length`, should be specified as a CWL `string` type to allow for greatest flexibility, e.g.:

```yaml
length:
  25 Angstroms
```

(Floats also work, but they don't allow the user to specify the requirement using a different unit or notation. All BioSimSpace requirement types can be implicitly converted from a string.)

Unfortunately CWL currently doesn't have support for placing restrictions/constraints on the input values. See [here](https://github.com/common-workflow-language/common-workflow-language/issues/764) for a discussion. This means that other tools can't use a CWL wrapper to generate handy things like widgets and dropdowns for specifying input requirements, like those used when a BioSimSpace node is run from within Jupyter. This can't be difficult to add, since it was easy to set up in BioSimSpace. I imagine it's just a case of agreeing on a scope/standard. There does seem to be some recent activity on the above thread, so hopefully it's something that's in the pipeline. (I don't see how it's possible to create useful KNIME nodes from a CWL wrapper unless this feature is added.)