### PR TITLE
OpenFF integration improvements

### DIFF
--- a/python/BioSimSpace/Parameters/Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/Protocol/_amber.py
@@ -372,6 +372,7 @@ class GAFF(_protocol.Protocol):
         except Exception as e:
             msg = "Failed to write system to 'PDB' format."
             if _isVerbose():
+                msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e
             else:
                 raise IOError(msg) from None
@@ -478,6 +479,7 @@ class GAFF(_protocol.Protocol):
                     except Exception as e:
                         msg = "Failed to read molecule from: 'leap.top', 'leap.crd'"
                         if _isVerbose():
+                            msg += ": " + getattr(e, "message", repr(e))
                             raise IOError(msg) from e
                         else:
                             raise IOError(msg) from None

--- a/python/BioSimSpace/Parameters/Protocol/_protocol.py
+++ b/python/BioSimSpace/Parameters/Protocol/_protocol.py
@@ -193,6 +193,7 @@ class Protocol():
         except Exception as e:
             msg = "Failed to read molecule from: '%s', '%s'" % (output[0], output[1])
             if _isVerbose():
+                msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e
             else:
                 raise IOError(msg) from None
@@ -240,6 +241,7 @@ class Protocol():
         except Exception as e:
             msg = "Failed to write system to 'PDB' format."
             if _isVerbose():
+                msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e
             else:
                 raise IOError(msg) from None
@@ -328,6 +330,7 @@ class Protocol():
         except Exception as e:
             msg = "Failed to write system to 'PDB' format."
             if _isVerbose():
+                msg += ": " + getattr(e, "message", repr(e))
                 raise IOError(msg) from e
             else:
                 raise IOError(msg) from None

--- a/python/BioSimSpace/Parameters/_process.py
+++ b/python/BioSimSpace/Parameters/_process.py
@@ -52,6 +52,7 @@ import threading as _threading
 import zipfile as _zipfile
 
 from BioSimSpace import _is_notebook
+from BioSimSpace import _isVerbose
 from BioSimSpace._Exceptions import ParameterisationError as _ParameterisationError
 from BioSimSpace._SireWrappers import Molecule as _Molecule
 
@@ -211,7 +212,10 @@ class Process():
 
         # If there was an problem, return the last error.
         if self._is_error:
-            raise _ParameterisationError("Parameterisation failed! Last error: '%s'" % str(self._last_error)) from None
+            if _isVerbose():
+                raise _ParameterisationError("Parameterisation failed! Last error: '%s'" % str(self._last_error))
+            else:
+                raise _ParameterisationError("Parameterisation failed! Last error: '%s'" % str(self._last_error)) from None
 
         return self._new_molecule
 

--- a/python/BioSimSpace/_Exceptions/_exceptions.py
+++ b/python/BioSimSpace/_Exceptions/_exceptions.py
@@ -29,7 +29,8 @@ __email_ = "lester.hedges@gmail.com"
 __all__ = ["AlignmentError",
            "IncompatibleError",
            "MissingSoftwareError",
-           "ParameterisationError"]
+           "ParameterisationError",
+           "ThirdPartyError"]
 
 class AlignmentError(Exception):
     """Exception thrown when molecular alignment fails."""
@@ -46,3 +47,6 @@ class MissingSoftwareError(Exception):
 class ParameterisationError(Exception):
     """Exception thrown when molecular parameterisation fails."""
     pass
+
+class ThirdPartyError(Exception):
+    """Exception thrown by a third party package."""


### PR DESCRIPTION
Following yesterday's discussions, I have implemented @j-wags and @mattwthompson's recommendation to create an OpenFF Molecule using an intermediate SDF file written by RDKit, since this quietly handles some tricky sanitisation issues.

I've also added some fixes to correctly expand verbose error messages when the parameterisation process is run as a background thread.