### PR TITLE
OMM Device index bug fix

### DIFF
--- a/python/BioSimSpace/Process/_openmm.py
+++ b/python/BioSimSpace/Process/_openmm.py
@@ -1496,22 +1496,7 @@ class OpenMM(_process.Process):
         # Set the simulation platform.
         self.addToConfig("\n# Set the simulation platform.")
         self.addToConfig(f"platform = Platform.getPlatformByName('{self._platform}')")
-        if self._platform == "CPU":
-            self.addToConfig("properties = {}")
-        elif self._platform == "CUDA":
-            cuda_devices = _os.environ.get("CUDA_VISIBLE_DEVICES")
-            if cuda_devices is None:
-                raise EnvironmentError("'CUDA' platform selected but 'CUDA_VISIBLE_DEVICES' "
-                                        "environment variable is unset.")
-            else:
-                self.addToConfig(f"properties = {'CudaDeviceIndex': {cuda_devices}}")
-        elif self._platform == "OPENCL":
-            opencl_devices = _os.environ.get("OPENCL_VISIBLE_DEVICES")
-            if opencl_devices is None:
-                raise EnvironmentError("'OpenCL' platform selected but 'OPENCL_VISIBLE_DEVICES' "
-                                        "environment variable is unset.")
-            else:
-                self.addToConfig(f"properties = {'OpenCLDeviceIndex': {opencl_devices}}")
+        self.addToConfig("properties = {}")
 
     def _add_config_monkey_patches(self):
         """Helper function to write any monkey-patches to the OpenMM Python


### PR DESCRIPTION
Fixes a bug that looks like this 
```
File "/home/dom/anaconda3/envs/bss/lib/python3.7/site-packages/simtk/openmm/app/simulation.py", line 105, in __init__
             self.context = mm.Context(self.system, self.integrator, platform, platformProperties)
         File "/home/dom/anaconda3/envs/bss/lib/python3.7/site-packages/simtk/openmm/openmm.py", line 18607, in __init__
             this = _openmm.new_Context(*args)
         NotImplementedError: Wrong number or type of arguments for overloaded function 'new_Context'.
         Possible C/C++ prototypes are:
             OpenMM::Context::Context(OpenMM::System const &,OpenMM::Integrator &)
             OpenMM::Context::Context(OpenMM::System const &,OpenMM::Integrator &,OpenMM::Platform &)
         OpenMM::Context::Context(OpenMM::System const &,OpenMM::Integrator &,OpenMM::Platform &,std::map< std::string,std::string,std::less< std::string >,std::allocator< std::pair< std::string const,std
::string > > > const &)
         OpenMM::Context::Context(OpenMM::Context const &)
```
It basically doesn't support  `properties = {CudaDeviceIndex: cuda_devices}`, when I select CUDA as the platform. Simply giving `properties = {}` fixes the issue. Relevant to #194 
