### PR TITLE
Feature feed lomap scores

### DIFF
--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -171,14 +171,27 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
         # check if all the molecule transformations are in the passed file.
         perturbations = _itertools.combinations(names, 2)
-        with open(scores_file) as scores_file_:
-          contents = repr(scores_file_.read())
+        with open(scores_file, "r") as scores_file_:
+          contents = []
+          for line in scores_file_:
+            # check that str,str,float. Because of how file is parsed, 
+            # lig1_name and lig2_name are always str.
+            lig1_name, lig2_name, score = line.rstrip().split(",")
+            try: 
+              float(score)
+            except ValueError:
+              raise ValueError(f"{scores_file} contains a non-numerical value on third "\
+                                +f"column ({line.rstrip()}). Make sure that each line "\
+                                +"in the file is formatted as str,str,value.")
+            contents.append(line.rstrip())
 
+          # check that all possible perturbations in the ligand series are accounted for in
+          # the scores_file.
           for pert in perturbations:
-            if not f"{pert[0]},{pert[1]}" in contents:
+            if not f"{pert[0]},{pert[1]}" in ",".join(contents):
 
               # check the opposite direction as well.
-              if not f"{pert[1]},{pert[0]}" in contents:
+              if not f"{pert[1]},{pert[0]}" in ",".join(contents):
 
                 raise ValueError(f"Could not find {pert[0]},{pert[1]} (or the inverse) "+\
                   f"in {scores_file}. Make sure your input file contains all possible transformations.")

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -38,6 +38,7 @@ import os as _os
 import subprocess as _subprocess
 import sys as _sys
 import tempfile as _tempfile
+import itertools
 
 import warnings as _warnings
 # Suppress numpy warnings from RDKit import.
@@ -76,7 +77,7 @@ except:
     _fkcombu_exe = None
 
 def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
-        input_scores=None, property_map={}):
+        scores_file=None, property_map={}):
     """Generate a perturbation network using Lead Optimisation Mappper (LOMAP).
 
        Parameters
@@ -97,10 +98,13 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
            If using a 'work_dir', then a PNG image will be located in
            'work_dir/images/network.png'.
 
-       input_scores : [float]
-           A list of float values (0.0-0.1) for the molecules. If defined, LOMAP will 
-           use these values to score molecular transformations instead of using its
-           own LOMAP score.
+       scores_file : str
+           Path to a CSV file in the form:
+           lig1,lig2,score
+           ..
+           lig_ lig_,score
+           , where score is a float that is fed into LOMAP for edge scoring
+           (instead of the default LOMAP score based on MCSS).
 
        property_map : dict
            A dictionary that maps "properties" in molecule0 to their user
@@ -154,17 +158,27 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
     if type(property_map) is not dict:
         raise TypeError("'property_map' must be of type 'dict'")
 
-    # Validate the input scores.
-    if input_scores is not None:
-      if type(input_scores) is not list:
-          raise TypeError("'input_scores' must be of type 'list'")
-      else:
-          # Check that all values in the list are floats.
-          if not all(isinstance(i, float) for i in input_scores):
-              raise ValueError("'input_scores' values must be of type float.")
-          # Check that all values in list are floats between 0 and 1.
-          if not all(0 <= i <= 1 for i in input_scores):
-              raise ValueError("'input_scores' values must be between 0 and 1.")
+    # Validate the scores file.
+    if scores_file is not None:
+      if type(scores_file) is not str:
+          raise TypeError("'input_scores' must be of type 'str'")
+      if names is None:
+          raise ValueError("'names' must be defined when passing 'scores_file' to LOMAP.")
+
+      # check if all the molecule transformations are in the passed file.
+      perturbations = itertools.combinations(names, 2)
+      with open(scores_file) as scores_file_:
+        contents = repr(scores_file_.read())
+
+        for pert in perturbations:
+          if not f"{pert[0]},{pert[1]}" in contents:
+
+            # check the opposite direction as well.
+            if not f"{pert[1]},{pert[0]}" in contents:
+
+              raise ValueError(f"Could not find {pert[0]},{pert[1]} (or the inverse) "+\
+                f"in {scores_file}. Make sure your input file contains all possible transformations.")
+
 
     # Create a temporary working directory and store the directory name.
     if work_dir is None:
@@ -190,13 +204,22 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
         _IO.saveMolecules(work_dir + f"/inputs/{x:03d}_{name}",
             molecule, "mol2", property_map=property_map)
 
+    # Write the scores file to disk (if defined).
+    if scores_file:
+      _os.popen(f"cp {scores_file} {work_dir}/inputs/lomap_input_edge_scores.csv")
+
     # Get the name of the LOMAP script.
     lomap_script = _os.path.dirname(__file__) + "/_lomap/lomap_networkgen.py"
 
     # Generate the command-line string.
-    command = f"{_sys.executable} {lomap_script} " \
-      + f"{work_dir}/inputs -n {work_dir}/outputs/lomap " \
-      + "--threed --max3d 3.0 -f"
+    if scores_file is not None:
+      command = f"{_sys.executable} {lomap_script} " \
+        + f"{work_dir}/inputs -n {work_dir}/outputs/lomap " \
+        + f"--threed --max3d 3.0 --ml_pd {work_dir}/inputs/lomap_input_edge_scores.csv"
+    else:
+      command = f"{_sys.executable} {lomap_script} " \
+        + f"{work_dir}/inputs -n {work_dir}/outputs/lomap " \
+        + "--threed --max3d 3.0"
 
     # Create files for stdout/stderr.
     stdout = open(work_dir + "/lomap.out", "w")
@@ -265,10 +288,10 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
         # 1) Loop over each molecule and load into RDKit.
         try:
-            rdmols = []
-            for x in range(0, len(molecules)):
-                file = f"{work_dir}/inputs/{x:03d}.pdb"
-                rdmols.append(_Chem.MolFromPDBFile(file, sanitize=False, removeHs=False))
+          rdmols = []
+          for x, name in zip(range(0, len(molecules)), names):
+              file = f"{work_dir}/inputs/{x:03d}_{name}.mol2"
+              rdmols.append(_Chem.rdmolfiles.MolFromMol2File(file, sanitize=False, removeHs=False))
 
         except Exception as e:
             msg = "Unable to load molecule into RDKit!"
@@ -296,6 +319,8 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
             for x, mol in enumerate(rdmols):
                 _AllChem.Compute2DCoords(mol)
                 _AllChem.GenerateDepictionMatching2DStructure(mol, template)
+                
+                mol = _Chem.RemoveHs(mol)
                 _Draw.MolToFile(mol, f"{work_dir}/images/{x:03d}.png")
 
         except Exception as e:
@@ -339,18 +364,18 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
         # 5) Create and display the plot.
         try:
-            # Convert to a dot graph.
-            dot_graph = _nx.drawing.nx_pydot.to_pydot(graph)
+          # Convert to a dot graph.
+          dot_graph = _nx.drawing.nx_pydot.to_pydot(graph)
 
-            # Write to a PNG.
-            network_plot = f"{work_dir}/images/network.png"
-            dot_graph.write_png(network_plot)
+          # Write to a PNG.
+          network_plot = f"{work_dir}/images/network.png"
+          dot_graph.write_png(network_plot)
 
-            # Create a plot of the network.
-            img = _mpimg.imread(network_plot)
-            _plt.figure(figsize=(20, 20))
-            _plt.axis("off")
-            _plt.imshow(img)
+          # Create a plot of the network.
+          img = _mpimg.imread(network_plot)
+          _plt.figure(figsize=(20, 20))
+          _plt.axis("off")
+          _plt.imshow(img)
 
         except Exception as e:
             msg = "Unable to create network plot!"

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -232,8 +232,8 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
             # that LOMAP indicates should be drawn.
             if row[7].strip() == "Yes":
                 # Extract the nodes (molecules) connected by the edge.
-                mol0 = int(row[2].rsplit(".")[0])
-                mol1 = int(row[3].rsplit(".")[0])
+                mol0 = int(row[2].rsplit(".")[0].rsplit("_")[0])
+                mol1 = int(row[3].rsplit(".")[0].rsplit("_")[0])
 
                 # Extract the score and convert to a float.
                 score = float(row[4])

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -38,7 +38,7 @@ import os as _os
 import subprocess as _subprocess
 import sys as _sys
 import tempfile as _tempfile
-import itertools
+import itertools as _itertools
 
 import warnings as _warnings
 # Suppress numpy warnings from RDKit import.
@@ -166,7 +166,7 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
           raise ValueError("'names' must be defined when passing 'scores_file' to LOMAP.")
 
       # check if all the molecule transformations are in the passed file.
-      perturbations = itertools.combinations(names, 2)
+      perturbations = _itertools.combinations(names, 2)
       with open(scores_file) as scores_file_:
         contents = repr(scores_file_.read())
 

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -104,7 +104,7 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
            ..
            lig_ lig_,score
            , where score is a float that is fed into LOMAP for edge scoring
-           (instead of the default LOMAP score based on MCSS).
+           (instead of the default LOMAP score based on Maximum Common Substructure (MCS)).
 
        property_map : dict
            A dictionary that maps "properties" in molecule0 to their user

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -160,25 +160,30 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
     # Validate the scores file.
     if scores_file is not None:
-      if type(scores_file) is not str:
-          raise TypeError("'input_scores' must be of type 'str'")
-      if names is None:
-          raise ValueError("'names' must be defined when passing 'scores_file' to LOMAP.")
 
-      # check if all the molecule transformations are in the passed file.
-      perturbations = _itertools.combinations(names, 2)
-      with open(scores_file) as scores_file_:
-        contents = repr(scores_file_.read())
+      # check that it exists.
+      if _os.path.isfile(scores_file):
 
-        for pert in perturbations:
-          if not f"{pert[0]},{pert[1]}" in contents:
+        if type(scores_file) is not str:
+            raise TypeError("'input_scores' must be of type 'str'")
+        if names is None:
+            raise ValueError("'names' must be defined when passing 'scores_file' to LOMAP.")
 
-            # check the opposite direction as well.
-            if not f"{pert[1]},{pert[0]}" in contents:
+        # check if all the molecule transformations are in the passed file.
+        perturbations = _itertools.combinations(names, 2)
+        with open(scores_file) as scores_file_:
+          contents = repr(scores_file_.read())
 
-              raise ValueError(f"Could not find {pert[0]},{pert[1]} (or the inverse) "+\
-                f"in {scores_file}. Make sure your input file contains all possible transformations.")
+          for pert in perturbations:
+            if not f"{pert[0]},{pert[1]}" in contents:
 
+              # check the opposite direction as well.
+              if not f"{pert[1]},{pert[0]}" in contents:
+
+                raise ValueError(f"Could not find {pert[0]},{pert[1]} (or the inverse) "+\
+                  f"in {scores_file}. Make sure your input file contains all possible transformations.")
+      else:
+        raise IOError(f"The scores file didn't exist: {scores_file}")
 
     # Create a temporary working directory and store the directory name.
     if work_dir is None:

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -174,15 +174,18 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
         with open(scores_file, "r") as scores_file_:
           contents = []
           for line in scores_file_:
-            # check that str,str,float. Because of how file is parsed, 
+            # check that str,str,float,x. Because of how file is parsed, 
             # lig1_name and lig2_name are always str.
-            lig1_name, lig2_name, score = line.rstrip().split(",")
+            records = line.rstrip().split(",")
+            if len(records) < 3:
+              raise ValueError(f"{scores_file} should have at least three entries per line (str,str,value). Failed line is {line.rstrip()}")
             try: 
-              float(score)
+              float(records[2])
             except ValueError:
               raise ValueError(f"{scores_file} contains a non-numerical value on third "\
                                 +f"column ({line.rstrip()}). Make sure that each line "\
                                 +"in the file is formatted as str,str,value.")
+
             contents.append(line.rstrip())
 
           # check that all possible perturbations in the ligand series are accounted for in

--- a/python/BioSimSpace/Align/_lomap/lomap_networkgen.py
+++ b/python/BioSimSpace/Align/_lomap/lomap_networkgen.py
@@ -79,7 +79,7 @@ class DBMolecules(object):
     def __init__(self, directory, parallel=1, verbose='off',
                  time=20, ecrscore=0.0, threed=False, max3d=1000.0, output=False,
                  name='out', output_no_images=False, output_no_graph=False, display=False,
-                 max=6, cutoff=0.4, radial=False, hub=None, fingerprint=False, fast=False, linksfile=None):
+                 max=6, cutoff=0.4, radial=False, hub=None, fingerprint=False, ml_pd=False, fast=False, linksfile=None):
 
         """
         Initialization of  the Molecule Database Class
@@ -166,6 +166,7 @@ class DBMolecules(object):
             parser.set_defaults(display=display)
             parser.set_defaults(radial=radial)
             parser.set_defaults(fingerprint=fingerprint)
+            parser.set_defaults(ml_pd=ml_pd)
             parser.set_defaults(fast=fast)
             parser.set_defaults(threed=threed)
             if output:
@@ -409,7 +410,7 @@ class DBMolecules(object):
             return self.mcs_map_store[idx]
         return None
 
-    def compute_mtx(self, a, b, strict_mtx, loose_mtx, ecr_mtx, MCS_map, fingerprint=False):
+    def compute_mtx(self, a, b, strict_mtx, loose_mtx, ecr_mtx, MCS_map, ml_pd=False, fingerprint=False):
         """
         Compute a chunk of the similarity score matrices. The chunk is selected
         by the start index a and the final index b. The matrices are indeed
@@ -440,6 +441,8 @@ class DBMolecules(object):
         MCS_map: dict (multiprocessing)
             Holds a dict of (index tuple) -> string with the strings being the
             MCS atom index map between the two molecules
+        
+        ml_pd: ...
 
         fingerprint: boolean
            using the structural fingerprint as the similarity matrix,
@@ -530,11 +533,20 @@ class DBMolecules(object):
                         logging.info('MCS molecules: %s - %s' % (self[i].getName(), self[j].getName()))
 
                     if not fingerprint:
-                        # Maximum Common Subgraph (MCS) calculation
-                        MC = mcs.MCS(moli, molj, options=self.options)
-                        ml=MC.all_atom_match_list()
-                        self.set_MCSmap(i,j,ml)
-                        MCS_map[(i,j)]=ml
+                        if ml_pd:
+                            # get the value from a file in work_dir?
+                            ml_pd_val = np.random.uniform(0, 5)
+
+                            # Use pre-computed perturbation difficulty values.
+                            # Because the ML predictor predicts SEM values, we need to invert such that
+                            # perturbations with low predicted SEM are favoured by LOMAP.
+                            ml_pd_val = 1/ml_pd_val
+                        else:
+                            # Maximum Common Subgraph (MCS) calculation
+                            MC = mcs.MCS(moli, molj, options=self.options)
+                            ml=MC.all_atom_match_list()
+                            self.set_MCSmap(i,j,ml)
+                            MCS_map[(i,j)]=ml
                     else:
                         # use the fingerprint as similarity calculation
                         fps_moli = FingerprintMols.FingerprintMol(moli)
@@ -556,19 +568,29 @@ class DBMolecules(object):
             # The scoring between the two molecules is performed by using different rules.
             # The total score will be the product of all the single rules
             if not fingerprint:
-                tmp_scr = ecr_score * MC.mncar() * MC.mcsr() * MC.atomic_number_rule() * MC.hybridization_rule()
-                tmp_scr *= MC.sulfonamides_rule() * MC.heterocycles_rule() * MC.transmuting_methyl_into_ring_rule()
-                tmp_scr *= MC.transmuting_ring_sizes_rule()
-                # Note - no longer using tmcsr rule!
-                strict_scr = tmp_scr * 1 #  MC.tmcsr(strict_flag=True)
-                loose_scr = tmp_scr * 1 #  MC.tmcsr(strict_flag=False)
-                strict_mtx[k] = strict_scr
-                loose_mtx[k] = loose_scr
-                ecr_mtx[k] = strict_scr
-                logging.info(
-                    'MCS molecules: %s - %s final score %s from ecr %s mncar %s mcsr %s tmcsr %s anum %s sulf %s het %s RingMe %s' %
-                      (self[i].getName(), self[j].getName(), strict_scr, ecr_score, MC.mncar(),MC.mcsr(),MC.tmcsr(strict_flag=True),
-                        MC.atomic_number_rule(),MC.sulfonamides_rule(),MC.heterocycles_rule(),MC.transmuting_methyl_into_ring_rule()))
+                if ml_pd:
+                    # for the ml_pd option, currently just use the identical strict and loose mtx
+                    strict_scr = ml_pd_val
+                    loose_scr = ml_pd_val
+                    strict_mtx[k] = strict_scr
+                    loose_mtx[k] = loose_scr
+                    ecr_mtx[k] = strict_scr
+                    logging.info(
+                        'MCS molecules: %s - %s the strict scr is %s' % (self[i].getName(), self[j].getName(), strict_scr))
+                else:
+                    tmp_scr = ecr_score * MC.mncar() * MC.mcsr() * MC.atomic_number_rule() * MC.hybridization_rule()
+                    tmp_scr *= MC.sulfonamides_rule() * MC.heterocycles_rule() * MC.transmuting_methyl_into_ring_rule()
+                    tmp_scr *= MC.transmuting_ring_sizes_rule()
+                    # Note - no longer using tmcsr rule!
+                    strict_scr = tmp_scr * 1 #  MC.tmcsr(strict_flag=True)
+                    loose_scr = tmp_scr * 1 #  MC.tmcsr(strict_flag=False)
+                    strict_mtx[k] = strict_scr
+                    loose_mtx[k] = loose_scr
+                    ecr_mtx[k] = strict_scr
+                    logging.info(
+                        'MCS molecules: %s - %s final score %s from ecr %s mncar %s mcsr %s tmcsr %s anum %s sulf %s het %s RingMe %s' %
+                          (self[i].getName(), self[j].getName(), strict_scr, ecr_score, MC.mncar(),MC.mcsr(),MC.tmcsr(strict_flag=True),
+                            MC.atomic_number_rule(),MC.sulfonamides_rule(),MC.heterocycles_rule(),MC.transmuting_methyl_into_ring_rule()))
             else:
                 # for the fingerprint option, currently just use the identical strict and loose mtx
                 strict_scr = fps_tan
@@ -608,13 +630,14 @@ class DBMolecules(object):
 
         if self.options.parallel == 1:  # Serial execution
             MCS_map = {}
-            self.compute_mtx(0, l - 1, self.strict_mtx, self.loose_mtx, self.ecr_mtx, MCS_map, self.options.fingerprint)
+            self.compute_mtx(0, l - 1, self.strict_mtx, self.loose_mtx, self.ecr_mtx, MCS_map, self.options.ml_pd, self.options.fingerprint)
             for idx in MCS_map:
               self.set_MCSmap(idx[0],idx[1],MCS_map[idx])
         else:
             # Parallel execution
-            # add the fingerprint option
+            # add the fingerprint and ml_pd option
             fingerprint = self.options.fingerprint
+            ml_pd = self.options.ml_pd
 
             logging.info('Parallel mode is on')
 
@@ -656,7 +679,7 @@ class DBMolecules(object):
 
                   # Python multiprocessing allocation
                   p = multiprocessing.Process(target=self.compute_mtx,
-                                              args=(i, j, strict_mtx, loose_mtx, ecr_mtx, MCS_map, fingerprint,))
+                                              args=(i, j, strict_mtx, loose_mtx, ecr_mtx, MCS_map, ml_pd, fingerprint))
                   p.start()
                   proc.append(p)
               # End parallel execution
@@ -1036,7 +1059,7 @@ def startup():
     # Molecule DataBase initialized with the passed user options
     db_mol = DBMolecules(ops.directory, ops.parallel, ops.verbose, ops.time, ops.ecrscore, ops.threed, ops.max3d,
                          ops.output, ops.name, ops.output_no_images, ops.output_no_graph, ops.display,
-                         ops.max, ops.cutoff, ops.radial, ops.hub, ops.fingerprint, ops.fast, ops.linksfile)
+                         ops.max, ops.cutoff, ops.radial, ops.hub, ops.ml_pd, ops.fingerprint, ops.fast, ops.linksfile)
     # Similarity score linear array generation
     strict, loose = db_mol.build_matrices()
 
@@ -1079,7 +1102,7 @@ out_group = parser.add_argument_group('Output setting')
 out_group.add_argument('-o', '--output', default=True, action='store_true', \
                        help='Generates output files')
 out_group.add_argument('-n', '--name', type=str, default='out', \
-                       help='File name prefix used to generate the output files')
+                       help='File name prefix used to generafte the output files')
 out_group.add_argument('--output-no-images', default=False, action='store_true', \
                        help='Disable the generation on the image files, removed the dependency on Pillow')
 out_group.add_argument('--output-no-graph', default=False, action='store_true', \
@@ -1097,6 +1120,8 @@ graph_group.add_argument('-r', '--radial', default=False, action='store_true', \
                          help='Using the radial option to build the graph')
 graph_group.add_argument('-b', '--hub', default=None, type=str, \
                          help='Using a radial graph approach with a manually specified hub compound')
+graph_group.add_argument('-ml', '--ml_pd', default=False, action='store_true', \
+                         help='Using the machine-learning perturbation difficulty option to build similarity matrices')
 graph_group.add_argument('-f', '--fingerprint', default=False, action='store_true', \
                          help='Using the fingerprint option to build similarity matrices')
 graph_group.add_argument('-a', '--fast', default=False, action='store_true', \

--- a/python/setup.py
+++ b/python/setup.py
@@ -37,7 +37,7 @@ try:
           license='GPLv2',
           packages=find_packages(),
           include_package_data=True,
-          zip_safe=True
+          zip_safe=False
         )
 
 # Post setup configuration.


### PR DESCRIPTION
Adjusted `_Align.py` such that it can now take in a variable `scores_file` (will throw an exception when `names` is not given simultaneously). This file contains user-input edge scorings that LOMAP can use instead of the native LOMAP score. `_Align.py` contains some checks to see if all possible combinations of `names` are in `scores_file`; the ordering should not matter for LOMAP because `lomap_networkgen.py` parses the file per perturbation.

I built the `--ml_pd` parameter and subsequent `ml_pd` path string passing in a similar way to how the fingerprint (`-f`) is passed to `compute_mtx()`.

Bonus: adjusted `generateNetwork()` such that now it uses a .mol2 intermediate instead of .pdb by naming molecules as {index}_{name}.mol2. With some small changes in the rdkit preparation, now pydot plots molecules with bond orders and non-polar hydrogens removed. 