### PR TITLE
Feature multi step perturbation 3

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_free_energy.py
+++ b/python/BioSimSpace/FreeEnergy/_free_energy.py
@@ -149,8 +149,13 @@ class FreeEnergy():
                                  "Supported engines are: %r." % ", ".join(self._engines))
 
             # Make sure GROMACS is installed if GROMACS engine is selected.
-            if engine == "GROMACS" and _gmx_exe is None:
+            if engine == "GROMACS":
+              if _gmx_exe is None:
                 raise _MissingSoftwareError("Cannot use GROMACS engine as GROMACS is not installed!")
+                
+              if self._protocol.getPerturbationType() != "full":
+                raise NotImplementedError("GROMACS currently only support a 'full' perturbation"\
+                    +" type. Please use SOMD when running multistep perturbation types.")
         else:
             # Use SOMD as a default.
             engine = "SOMD"

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -161,10 +161,15 @@ class Gromacs(_process.Process):
         # If the we are performing a free energy simulation, then check that
         # the system contains a single perturbable molecule.
         if type(self._protocol) is _Protocol.FreeEnergy:
+            if self._protocol.getPerturbationType() != "full":
+                raise NotImplementedError("GROMACS currently only support a 'full' perturbation"\
+                    +" type. Please use SOMD when running multistep perturbation types.")
+
             if self._system.nPerturbableMolecules() != 1:
                 raise ValueError("'BioSimSpace.Protocol.FreeEnergy' requires a single "
                                  "perturbable molecule. The system has %d" \
                                   % system.nPerturbableMolecules())
+
 
         # Create a copy of the system.
         system = self._system.copy()

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -207,7 +207,9 @@ class Somd(_process.Process):
 
                 # Write the perturbation file and get the molecule corresponding
                 # to the lambda = 0 state.
-                pert_mol = pert_mol._toPertFile(self._pert_file, property_map=self._property_map)
+                pert_mol = pert_mol._toPertFile(self._pert_file, property_map=self._property_map,
+                                                pert_type=self._protocol.getPertType())
+
                 self._input_files.append(self._pert_file)
 
                 # Remove the perturbable molecule.

--- a/python/BioSimSpace/Process/_somd.py
+++ b/python/BioSimSpace/Process/_somd.py
@@ -208,7 +208,7 @@ class Somd(_process.Process):
                 # Write the perturbation file and get the molecule corresponding
                 # to the lambda = 0 state.
                 pert_mol = pert_mol._toPertFile(self._pert_file, property_map=self._property_map,
-                                                pert_type=self._protocol.getPertType())
+                                                perturbation_type=self._protocol.getPertType())
 
                 self._input_files.append(self._pert_file)
 

--- a/python/BioSimSpace/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Protocol/_free_energy.py
@@ -89,8 +89,13 @@ class FreeEnergy(_Protocol):
            restart_interval : int
                The frequency at which restart configurations and trajectory
            perturbation_type : str
-                Which type of perturbation to create a multistep free energy work_dir with. 
-                Defaults to standard, i.e. onestep.
+               The type of perturbation to perform. Options are:
+                'standard' : A full perturbation of all terms (default option).
+                '1_discharge_soft' : perturb all discharging soft atom charge terms (i.e. value->0.0).
+                '2_vanish_soft' : perturb all vanishing soft atom LJ terms (i.e. value->0.0).
+                '3_flip' : perturb all hard atom terms as well as bonds/angles.
+                '4_grow_soft' : perturb all growing soft atom LJ terms (i.e. 0.0->value).
+                '5_charge_soft' : perturb all charging soft atom LJ terms (i.e. 0.0->value).
         """
 
         # Call the base class constructor.

--- a/python/BioSimSpace/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Protocol/_free_energy.py
@@ -96,6 +96,8 @@ class FreeEnergy(_Protocol):
                 'flip' : perturb all hard atom terms as well as bonds/angles.
                 'grow_soft' : perturb all growing soft atom LJ terms (i.e. 0.0->value).
                 'charge_soft' : perturb all charging soft atom LJ terms (i.e. 0.0->value).
+
+                Currently GROMACS only supports perturbation_type=full.
         """
 
         # Call the base class constructor.

--- a/python/BioSimSpace/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Protocol/_free_energy.py
@@ -48,7 +48,8 @@ class FreeEnergy(_Protocol):
                  temperature=_Types.Temperature(300, "kelvin"),
                  pressure=_Types.Pressure(1, "atmosphere"),
                  report_interval=100,
-                 restart_interval=500
+                 restart_interval=500,
+                 pert_type="standard"
                 ):
         """Constructor.
 
@@ -87,6 +88,9 @@ class FreeEnergy(_Protocol):
 
            restart_interval : int
                The frequency at which restart configurations and trajectory
+           pert_type : str
+                Which type of perturbation to create a multistep free energy work_dir with. 
+                Defaults to standard, i.e. onestep.
         """
 
         # Call the base class constructor.
@@ -116,6 +120,9 @@ class FreeEnergy(_Protocol):
         # Set the restart interval.
         self.setRestartInterval(restart_interval)
 
+        # Set the perturbation type. Default is "standard", i.e. onestep protocol.
+        self.setPertType(pert_type)
+
     def __str__(self):
         """Return a human readable string representation of the object."""
         if self._is_customised:
@@ -135,6 +142,31 @@ class FreeEnergy(_Protocol):
                     "runtime=%s, temperature=%s, pressure=%s, report_interval=%d, restart_interval=%d)"
                    ) % (self._lambda, self._lambda_vals, self._timestep, self._runtime,
                         self._temperature, self._pressure, self._report_interval, self._restart_interval)
+
+    def getPertType(self):
+        """Get the type of step of the multistep approach to write. Default ("standard") is onestep.
+
+           Returns
+           -------
+
+           pert_type : str
+               The perturbation type.
+        """
+        return self._pert_type
+
+    def setPertType(self, pert_type):
+        """Set the time step.
+
+           Parameters
+           ----------
+
+           pert_type : str
+               The perturbation type.
+        """
+        if type(pert_type) is str:
+            self._pert_type = pert_type
+        else:
+            raise TypeError("'pert_type' must be of type str")
 
     def getLambda(self):
         """Get the value of the perturbation parameter.

--- a/python/BioSimSpace/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Protocol/_free_energy.py
@@ -49,7 +49,7 @@ class FreeEnergy(_Protocol):
                  pressure=_Types.Pressure(1, "atmosphere"),
                  report_interval=100,
                  restart_interval=500,
-                 pert_type="standard"
+                 perturbation_type="standard"
                 ):
         """Constructor.
 
@@ -88,7 +88,7 @@ class FreeEnergy(_Protocol):
 
            restart_interval : int
                The frequency at which restart configurations and trajectory
-           pert_type : str
+           perturbation_type : str
                 Which type of perturbation to create a multistep free energy work_dir with. 
                 Defaults to standard, i.e. onestep.
         """
@@ -121,7 +121,7 @@ class FreeEnergy(_Protocol):
         self.setRestartInterval(restart_interval)
 
         # Set the perturbation type. Default is "standard", i.e. onestep protocol.
-        self.setPertType(pert_type)
+        self.setPertType(perturbation_type)
 
     def __str__(self):
         """Return a human readable string representation of the object."""
@@ -149,24 +149,24 @@ class FreeEnergy(_Protocol):
            Returns
            -------
 
-           pert_type : str
+           perturbation_type : str
                The perturbation type.
         """
-        return self._pert_type
+        return self._perturbation_type
 
-    def setPertType(self, pert_type):
+    def setPertType(self, perturbation_type):
         """Set the time step.
 
            Parameters
            ----------
 
-           pert_type : str
+           perturbation_type : str
                The perturbation type.
         """
-        if type(pert_type) is str:
-            self._pert_type = pert_type
+        if type(perturbation_type) is str:
+            self._perturbation_type = perturbation_type
         else:
-            raise TypeError("'pert_type' must be of type str")
+            raise TypeError("'perturbation_type' must be of type str")
 
     def getLambda(self):
         """Get the value of the perturbation parameter.

--- a/python/BioSimSpace/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Protocol/_free_energy.py
@@ -49,7 +49,7 @@ class FreeEnergy(_Protocol):
                  pressure=_Types.Pressure(1, "atmosphere"),
                  report_interval=100,
                  restart_interval=500,
-                 perturbation_type="standard"
+                 perturbation_type="full"
                 ):
         """Constructor.
 
@@ -90,7 +90,7 @@ class FreeEnergy(_Protocol):
                The frequency at which restart configurations and trajectory
            perturbation_type : str
                The type of perturbation to perform. Options are:
-                'standard' : A full perturbation of all terms (default option).
+                'full' : A full perturbation of all terms (default option).
                 'discharge_soft' : perturb all discharging soft atom charge terms (i.e. value->0.0).
                 'vanish_soft' : perturb all vanishing soft atom LJ terms (i.e. value->0.0).
                 'flip' : perturb all hard atom terms as well as bonds/angles.
@@ -125,7 +125,7 @@ class FreeEnergy(_Protocol):
         # Set the restart interval.
         self.setRestartInterval(restart_interval)
 
-        # Set the perturbation type. Default is "standard", i.e. onestep protocol.
+        # Set the perturbation type. Default is "full", i.e. onestep protocol.
         self.setPertType(perturbation_type)
 
     def __str__(self):
@@ -149,7 +149,7 @@ class FreeEnergy(_Protocol):
                         self._temperature, self._pressure, self._report_interval, self._restart_interval)
 
     def getPertType(self):
-        """Get the type of step of the multistep approach to write. Default ("standard") is onestep.
+        """Get the type of step of the multistep approach to write. Default ("full") is onestep.
 
            Returns
            -------
@@ -174,7 +174,7 @@ class FreeEnergy(_Protocol):
             raise TypeError("'perturbation_type' must be of type 'str'")
 
         allowed_perturbation_types = [  
-                              "standard",
+                              "full",
                               "discharge_soft",
                               "vanish_soft",
                               "flip",

--- a/python/BioSimSpace/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Protocol/_free_energy.py
@@ -91,11 +91,11 @@ class FreeEnergy(_Protocol):
            perturbation_type : str
                The type of perturbation to perform. Options are:
                 'standard' : A full perturbation of all terms (default option).
-                '1_discharge_soft' : perturb all discharging soft atom charge terms (i.e. value->0.0).
-                '2_vanish_soft' : perturb all vanishing soft atom LJ terms (i.e. value->0.0).
-                '3_flip' : perturb all hard atom terms as well as bonds/angles.
-                '4_grow_soft' : perturb all growing soft atom LJ terms (i.e. 0.0->value).
-                '5_charge_soft' : perturb all charging soft atom LJ terms (i.e. 0.0->value).
+                'discharge_soft' : perturb all discharging soft atom charge terms (i.e. value->0.0).
+                'vanish_soft' : perturb all vanishing soft atom LJ terms (i.e. value->0.0).
+                'flip' : perturb all hard atom terms as well as bonds/angles.
+                'grow_soft' : perturb all growing soft atom LJ terms (i.e. 0.0->value).
+                'charge_soft' : perturb all charging soft atom LJ terms (i.e. 0.0->value).
         """
 
         # Call the base class constructor.
@@ -169,17 +169,17 @@ class FreeEnergy(_Protocol):
                The perturbation type.
         """
         perturbation_type = perturbation_type.lower().replace(" ", "")
-        
+
         if type(perturbation_type) is not str:
             raise TypeError("'perturbation_type' must be of type 'str'")
 
         allowed_perturbation_types = [  
                               "standard",
-                              "1_discharge_soft",
-                              "2_vanish_soft",
-                              "3_flip",
-                              "4_grow_soft",
-                              "5_charge_soft"]
+                              "discharge_soft",
+                              "vanish_soft",
+                              "flip",
+                              "grow_soft",
+                              "charge_soft"]
         if perturbation_type not in allowed_perturbation_types:
           raise ValueError("'perturbation_type' must be any of: "+str(allowed_perturbation_types), perturbation_type)
 

--- a/python/BioSimSpace/Protocol/_free_energy.py
+++ b/python/BioSimSpace/Protocol/_free_energy.py
@@ -168,10 +168,22 @@ class FreeEnergy(_Protocol):
            perturbation_type : str
                The perturbation type.
         """
-        if type(perturbation_type) is str:
-            self._perturbation_type = perturbation_type
-        else:
-            raise TypeError("'perturbation_type' must be of type str")
+        perturbation_type = perturbation_type.lower().replace(" ", "")
+        
+        if type(perturbation_type) is not str:
+            raise TypeError("'perturbation_type' must be of type 'str'")
+
+        allowed_perturbation_types = [  
+                              "standard",
+                              "1_discharge_soft",
+                              "2_vanish_soft",
+                              "3_flip",
+                              "4_grow_soft",
+                              "5_charge_soft"]
+        if perturbation_type not in allowed_perturbation_types:
+          raise ValueError("'perturbation_type' must be any of: "+str(allowed_perturbation_types), perturbation_type)
+
+        self._perturbation_type = perturbation_type
 
     def getLambda(self):
         """Get the value of the perturbation parameter.

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1215,7 +1215,7 @@ class Molecule(_SireWrapper):
         if not _path.isfile(filename):
             raise IOError("Perturbation file doesn't exist: '%s'" % filename)
 
-    def _toPertFile(molecule, filename="MORPH.pert", zero_dummy_dihedrals=False,
+    def _toPertFile(self, filename="MORPH.pert", zero_dummy_dihedrals=False,
             zero_dummy_impropers=False, print_all_atoms=False, property_map={},
             pert_type="standard"):
         """Write the merged molecule to a perturbation file.
@@ -1253,10 +1253,10 @@ class Molecule(_SireWrapper):
            molecule : Sire.Mol.Molecule
                The molecule with properties corresponding to the lamda = 0 state.
         """
-        if not molecule._is_merged:
+        if not self._is_merged:
             raise _IncompatibleError("This isn't a merged molecule. Cannot write perturbation file!")
 
-        if not molecule._sire_object.property("forcefield0").isAmberStyle():
+        if not self._sire_object.property("forcefield0").isAmberStyle():
             raise _IncompatibleError("Can only write perturbation files for AMBER style force fields.")
 
         if type(zero_dummy_dihedrals) is not bool:
@@ -1290,7 +1290,7 @@ class Molecule(_SireWrapper):
             raise ValueError("'pert_type' must be any of: "+str(allowed_pert_types), pert_type)
 
         # Extract and copy the Sire molecule.
-        mol = molecule._sire_object.__deepcopy__()
+        mol = self._sire_object.__deepcopy__()
 
         # First work out the indices of atoms that are perturbed.
         pert_idxs = []

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1281,11 +1281,11 @@ class Molecule(_SireWrapper):
 
           allowed_perturbation_types = [  
                                 "standard",
-                                "1_discharge_soft",
-                                "2_vanish_soft",
-                                "3_flip",
-                                "4_grow_soft",
-                                "5_charge_soft"]
+                                "discharge_soft",
+                                "vanish_soft",
+                                "flip",
+                                "grow_soft",
+                                "charge_soft"]
           if perturbation_type not in allowed_perturbation_types:
             raise ValueError("'perturbation_type' must be any of: "+str(allowed_perturbation_types), perturbation_type)
 
@@ -1497,7 +1497,7 @@ class Molecule(_SireWrapper):
                     
                     # set LJ/charge based on requested perturbed term.
                     #######################################################################
-                    if perturbation_type == "1_discharge_soft":
+                    if perturbation_type == "discharge_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1527,7 +1527,7 @@ class Molecule(_SireWrapper):
                             charge0_value = charge1_value = atom.property("charge0").value()
 
                     #######################################################################
-                    elif perturbation_type == "2_vanish_soft":
+                    elif perturbation_type == "vanish_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1561,7 +1561,7 @@ class Molecule(_SireWrapper):
 
 
                     #######################################################################
-                    elif perturbation_type == "3_flip":
+                    elif perturbation_type == "flip":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1592,7 +1592,7 @@ class Molecule(_SireWrapper):
                             charge1_value = atom.property("charge1").value()
 
                     #######################################################################
-                    elif perturbation_type == "4_grow_soft":
+                    elif perturbation_type == "grow_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1626,7 +1626,7 @@ class Molecule(_SireWrapper):
                             charge0_value = charge1_value = atom.property("charge1").value()
 
                     #######################################################################
-                    elif perturbation_type == "5_charge_soft":
+                    elif perturbation_type == "charge_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1782,8 +1782,8 @@ class Molecule(_SireWrapper):
                 # Start bond record.
                 file.write("    bond\n")
                 if perturbation_type in [
-                    "1_discharge_soft",
-                    "2_vanish_soft"
+                    "discharge_soft",
+                    "vanish_soft"
                                 ]:
                     # Bond data is unchanged.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
@@ -1793,7 +1793,7 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % 0.0)
                     file.write("        final_equil    %.5f\n" % amber_bond.r0())
 
-                elif perturbation_type == "3_flip" or perturbation_type == "standard":
+                elif perturbation_type == "flip" or perturbation_type == "standard":
                     # bonds are perturbed.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1803,8 +1803,8 @@ class Molecule(_SireWrapper):
                     file.write("        final_equil    %.5f\n" % amber_bond.r0())                
 
                 elif perturbation_type in [
-                    "4_grow_soft",
-                    "5_charge_soft"
+                    "grow_soft",
+                    "charge_soft"
                                 ]:
                     # Bond data has already been changed, assume endpoints.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
@@ -1862,8 +1862,8 @@ class Molecule(_SireWrapper):
                         # Start bond record.
                         file.write("    bond\n")
                         if perturbation_type in [
-                            "1_discharge_soft",
-                            "2_vanish_soft"
+                            "discharge_soft",
+                            "vanish_soft"
                                         ]:
                             # Bonds are not perturbed.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
@@ -1872,7 +1872,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_equil  %.5f\n" % amber_bond0.r0())
                             file.write("        final_force    %.5f\n" % amber_bond0.k())
                             file.write("        final_equil    %.5f\n" % amber_bond0.r0())
-                        elif perturbation_type == "3_flip" or perturbation_type == "standard":
+                        elif perturbation_type == "flip" or perturbation_type == "standard":
                             # Bonds are perturbed.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1881,8 +1881,8 @@ class Molecule(_SireWrapper):
                             file.write("        final_force    %.5f\n" % amber_bond1.k())
                             file.write("        final_equil    %.5f\n" % amber_bond1.r0())
                         elif perturbation_type in [
-                            "4_grow_soft",
-                            "5_charge_soft"
+                            "grow_soft",
+                            "charge_soft"
                                         ]:
                             # Bonds are already perturbed.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
@@ -1987,7 +1987,7 @@ class Molecule(_SireWrapper):
                 # Start angle record.
                 file.write("    angle\n")
 
-                if perturbation_type in ["standard", "3_flip"]:
+                if perturbation_type in ["standard", "flip"]:
                     # Angle data.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1997,8 +1997,8 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % 0.0)
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())
                 elif perturbation_type in [
-                    "1_discharge_soft",
-                    "2_vanish_soft"]:
+                    "discharge_soft",
+                    "vanish_soft"]:
                     # Angle data, unperturbed.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2008,8 +2008,8 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % amber_angle.k())
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())                
                 elif perturbation_type in [
-                    "4_grow_soft",
-                    "5_charge_soft"]:
+                    "grow_soft",
+                    "charge_soft"]:
                     # Angle data, already perturbed.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2038,7 +2038,7 @@ class Molecule(_SireWrapper):
                 # Start angle record.
                 file.write("    angle\n")
 
-                if perturbation_type in ["standard", "3_flip"]:
+                if perturbation_type in ["standard", "flip"]:
                     # Angle data.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2048,8 +2048,8 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % amber_angle.k())
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())
                 elif perturbation_type in [
-                    "1_discharge_soft",
-                    "2_vanish_soft"]:
+                    "discharge_soft",
+                    "vanish_soft"]:
                     # Angle data, unperturbed.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2059,8 +2059,8 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % 0.0)
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())                
                 elif perturbation_type in [
-                    "4_grow_soft",
-                    "5_charge_soft"]:
+                    "grow_soft",
+                    "charge_soft"]:
                     # Angle data, already perturbed.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2117,7 +2117,7 @@ class Molecule(_SireWrapper):
                         # Start angle record.
                         file.write("    angle\n")
                         
-                        if perturbation_type in ["standard", "3_flip"]:
+                        if perturbation_type in ["standard", "flip"]:
                             # Angle data.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2127,8 +2127,8 @@ class Molecule(_SireWrapper):
                             file.write("        final_force    %.5f\n" % amber_angle1.k())
                             file.write("        final_equil    %.5f\n" % amber_angle1.theta0())
                         elif perturbation_type in [
-                            "1_discharge_soft",
-                            "2_vanish_soft"]:
+                            "discharge_soft",
+                            "vanish_soft"]:
                             # Angle data, unperturbed.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2138,8 +2138,8 @@ class Molecule(_SireWrapper):
                             file.write("        final_force    %.5f\n" % amber_angle0.k())
                             file.write("        final_equil    %.5f\n" % amber_angle0.theta0())             
                         elif perturbation_type in [
-                            "4_grow_soft",
-                            "5_charge_soft"]:
+                            "grow_soft",
+                            "charge_soft"]:
                             # Angle data, already perturbed.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2258,9 +2258,9 @@ class Molecule(_SireWrapper):
                     amber_dihedral.terms(), key=lambda t: (t.k(), t.periodicity(), t.phase()))
                 for term in amber_dihedral_terms_sorted:
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft",
-                        "3_flip",
+                        "discharge_soft",
+                        "vanish_soft",
+                        "flip",
                         "standard"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
                     else: 
@@ -2270,8 +2270,8 @@ class Molecule(_SireWrapper):
 
                 for term in amber_dihedral_terms_sorted:
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft"]:
+                        "discharge_soft",
+                        "vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
                     else:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
@@ -2308,9 +2308,9 @@ class Molecule(_SireWrapper):
                     amber_dihedral.terms(), key=lambda t: (t.k(), t.periodicity(), t.phase()))
                 for term in amber_dihedral_terms_sorted:
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft",
-                        "3_flip",
+                        "discharge_soft",
+                        "vanish_soft",
+                        "flip",
                         "standard"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
                     else: 
@@ -2320,8 +2320,8 @@ class Molecule(_SireWrapper):
                 file.write("        final_form    ")
                 for term in amber_dihedral_terms_sorted:
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft"]:
+                        "discharge_soft",
+                        "vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
                     else:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
@@ -2409,7 +2409,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_form  ")
 
 
-                            if perturbation_type in ["standard", "3_flip"]:
+                            if perturbation_type in ["standard", "flip"]:
                                 # do the standard approach.      
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
@@ -2429,7 +2429,7 @@ class Molecule(_SireWrapper):
                                     file.write(" %5.4f %.1f %7.6f" % (k, term.periodicity(), term.phase()))
                                 file.write("\n")
 
-                            elif perturbation_type in ["1_discharge_soft", "2_vanish_soft"]:
+                            elif perturbation_type in ["discharge_soft", "vanish_soft"]:
                                 # Don't perturb dihedrals, i.e. change k1 to k0.
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
@@ -2580,9 +2580,9 @@ class Molecule(_SireWrapper):
                     amber_dihedral.terms(), key=lambda t: (t.k(), t.periodicity(), t.phase()))
                 for term in amber_dihedral_terms_sorted:
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft",
-                        "3_flip",
+                        "discharge_soft",
+                        "vanish_soft",
+                        "flip",
                         "standard"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
                     else:
@@ -2592,8 +2592,8 @@ class Molecule(_SireWrapper):
                 file.write("        final form    ")
                 for term in amber_dihedral_terms_sorted:
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft"]:
+                        "discharge_soft",
+                        "vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
 
                     else:
@@ -2629,9 +2629,9 @@ class Molecule(_SireWrapper):
                 for term in sorted(amber_dihedral0.terms(),
                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft",
-                        "3_flip",
+                        "discharge_soft",
+                        "vanish_soft",
+                        "flip",
                         "standard"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
                     else:
@@ -2641,8 +2641,8 @@ class Molecule(_SireWrapper):
                 for term in sorted(amber_dihedral1.terms(),
                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
                     if perturbation_type in [
-                        "1_discharge_soft",
-                        "2_vanish_soft"]:
+                        "discharge_soft",
+                        "vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
                     else:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
@@ -2726,7 +2726,7 @@ class Molecule(_SireWrapper):
                             file.write("        atom3          %s\n" % mol.atom(idx3).name().value())
                             file.write("        initial_form  ")
 
-                            if perturbation_type in ["standard", "3_flip"]:
+                            if perturbation_type in ["standard", "flip"]:
                                 # do the standard approach.      
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
@@ -2746,7 +2746,7 @@ class Molecule(_SireWrapper):
                                     file.write(" %5.4f %.1f %7.6f" % (k, term.periodicity(), term.phase()))
                                 file.write("\n")
 
-                            elif perturbation_type in ["1_discharge_soft", "2_vanish_soft"]:
+                            elif perturbation_type in ["discharge_soft", "vanish_soft"]:
                                 # Don't perturb dihedrals, i.e. change k1 to k0.
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1217,7 +1217,7 @@ class Molecule(_SireWrapper):
 
     def _toPertFile(self, filename="MORPH.pert", zero_dummy_dihedrals=False,
             zero_dummy_impropers=False, print_all_atoms=False, property_map={},
-            perturbation_type="standard"):
+            perturbation_type="full"):
         """Write the merged molecule to a perturbation file.
 
            Parameters
@@ -1244,7 +1244,7 @@ class Molecule(_SireWrapper):
                own naming scheme, e.g. { "charge" : "my-charge" }
 
            perturbation_type : str
-               String that specifies whether to use the 'standard' or 'multistep'
+               String that specifies whether to use the 'full' or 'multistep'
                approach in perturbing the LJ, bond and angle terms.
 
            Returns
@@ -1280,7 +1280,7 @@ class Molecule(_SireWrapper):
               raise TypeError("'perturbation_type' must be of type 'str'")
 
           allowed_perturbation_types = [  
-                                "standard",
+                                "full",
                                 "discharge_soft",
                                 "vanish_soft",
                                 "flip",
@@ -1430,7 +1430,7 @@ class Molecule(_SireWrapper):
                         LJ1.epsilon().value(),
                         atom.property("charge0").value(),
                         atom.property("charge1").value())
-            if perturbation_type == "standard":
+            if perturbation_type == "full":
                 if print_all_atoms:
                   for atom in sorted(mol.atoms(), key=lambda atom: atom_sorting_criteria(atom)):
                       # Start atom record.
@@ -1793,7 +1793,7 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % 0.0)
                     file.write("        final_equil    %.5f\n" % amber_bond.r0())
 
-                elif perturbation_type == "flip" or perturbation_type == "standard":
+                elif perturbation_type == "flip" or perturbation_type == "full":
                     # bonds are perturbed.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1872,7 +1872,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_equil  %.5f\n" % amber_bond0.r0())
                             file.write("        final_force    %.5f\n" % amber_bond0.k())
                             file.write("        final_equil    %.5f\n" % amber_bond0.r0())
-                        elif perturbation_type == "flip" or perturbation_type == "standard":
+                        elif perturbation_type == "flip" or perturbation_type == "full":
                             # Bonds are perturbed.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1987,7 +1987,7 @@ class Molecule(_SireWrapper):
                 # Start angle record.
                 file.write("    angle\n")
 
-                if perturbation_type in ["standard", "flip"]:
+                if perturbation_type in ["full", "flip"]:
                     # Angle data.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2038,7 +2038,7 @@ class Molecule(_SireWrapper):
                 # Start angle record.
                 file.write("    angle\n")
 
-                if perturbation_type in ["standard", "flip"]:
+                if perturbation_type in ["full", "flip"]:
                     # Angle data.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2117,7 +2117,7 @@ class Molecule(_SireWrapper):
                         # Start angle record.
                         file.write("    angle\n")
                         
-                        if perturbation_type in ["standard", "flip"]:
+                        if perturbation_type in ["full", "flip"]:
                             # Angle data.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2261,7 +2261,7 @@ class Molecule(_SireWrapper):
                         "discharge_soft",
                         "vanish_soft",
                         "flip",
-                        "standard"]:
+                        "full"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
                     else: 
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
@@ -2311,7 +2311,7 @@ class Molecule(_SireWrapper):
                         "discharge_soft",
                         "vanish_soft",
                         "flip",
-                        "standard"]:
+                        "full"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
                     else: 
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
@@ -2409,8 +2409,8 @@ class Molecule(_SireWrapper):
                             file.write("        initial_form  ")
 
 
-                            if perturbation_type in ["standard", "flip"]:
-                                # do the standard approach.      
+                            if perturbation_type in ["full", "flip"]:
+                                # do the full approach.      
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
                                     if zero_k and has_dummy_initial:
@@ -2583,7 +2583,7 @@ class Molecule(_SireWrapper):
                         "discharge_soft",
                         "vanish_soft",
                         "flip",
-                        "standard"]:
+                        "full"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
                     else:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
@@ -2632,7 +2632,7 @@ class Molecule(_SireWrapper):
                         "discharge_soft",
                         "vanish_soft",
                         "flip",
-                        "standard"]:
+                        "full"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
                     else:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
@@ -2726,8 +2726,8 @@ class Molecule(_SireWrapper):
                             file.write("        atom3          %s\n" % mol.atom(idx3).name().value())
                             file.write("        initial_form  ")
 
-                            if perturbation_type in ["standard", "flip"]:
-                                # do the standard approach.      
+                            if perturbation_type in ["full", "flip"]:
+                                # do the full approach.      
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
                                     if zero_k and has_dummy_initial:

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1217,7 +1217,7 @@ class Molecule(_SireWrapper):
 
     def _toPertFile(self, filename="MORPH.pert", zero_dummy_dihedrals=False,
             zero_dummy_impropers=False, print_all_atoms=False, property_map={},
-            pert_type="standard"):
+            perturbation_type="standard"):
         """Write the merged molecule to a perturbation file.
 
            Parameters
@@ -1243,7 +1243,7 @@ class Molecule(_SireWrapper):
                values. This allows the user to refer to properties with their
                own naming scheme, e.g. { "charge" : "my-charge" }
 
-           pert_type : str
+           perturbation_type : str
                String that specifies whether to use the 'standard' or 'multistep'
                approach in perturbing the LJ, bond and angle terms.
 
@@ -1275,19 +1275,19 @@ class Molecule(_SireWrapper):
         # This is helpful when debugging since we can directly compare pert files.
         _random.seed(42)        
 
-        if pert_type:
-          if type(pert_type) is not str:
-              raise TypeError("'pert_type' must be of type 'str'")
+        if perturbation_type:
+          if type(perturbation_type) is not str:
+              raise TypeError("'perturbation_type' must be of type 'str'")
 
-          allowed_pert_types = [  
+          allowed_perturbation_types = [  
                                 "standard",
                                 "1_discharge_soft",
                                 "2_vanish_soft",
                                 "3_flip",
                                 "4_grow_soft",
                                 "5_charge_soft"]
-          if pert_type not in allowed_pert_types:
-            raise ValueError("'pert_type' must be any of: "+str(allowed_pert_types), pert_type)
+          if perturbation_type not in allowed_perturbation_types:
+            raise ValueError("'perturbation_type' must be any of: "+str(allowed_perturbation_types), perturbation_type)
 
         # Extract and copy the Sire molecule.
         mol = self._sire_object.__deepcopy__()
@@ -1430,7 +1430,7 @@ class Molecule(_SireWrapper):
                         LJ1.epsilon().value(),
                         atom.property("charge0").value(),
                         atom.property("charge1").value())
-            if pert_type == "standard":
+            if perturbation_type == "standard":
                 if print_all_atoms:
                   for atom in sorted(mol.atoms(), key=lambda atom: atom_sorting_criteria(atom)):
                       # Start atom record.
@@ -1497,7 +1497,7 @@ class Molecule(_SireWrapper):
                     
                     # set LJ/charge based on requested perturbed term.
                     #######################################################################
-                    if pert_type == "1_discharge_soft":
+                    if perturbation_type == "1_discharge_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1527,7 +1527,7 @@ class Molecule(_SireWrapper):
                             charge0_value = charge1_value = atom.property("charge0").value()
 
                     #######################################################################
-                    elif pert_type == "2_vanish_soft":
+                    elif perturbation_type == "2_vanish_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1561,7 +1561,7 @@ class Molecule(_SireWrapper):
 
 
                     #######################################################################
-                    elif pert_type == "3_flip":
+                    elif perturbation_type == "3_flip":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1592,7 +1592,7 @@ class Molecule(_SireWrapper):
                             charge1_value = atom.property("charge1").value()
 
                     #######################################################################
-                    elif pert_type == "4_grow_soft":
+                    elif perturbation_type == "4_grow_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1626,7 +1626,7 @@ class Molecule(_SireWrapper):
                             charge0_value = charge1_value = atom.property("charge1").value()
 
                     #######################################################################
-                    elif pert_type == "5_charge_soft":
+                    elif perturbation_type == "5_charge_soft":
                         if (atom.property("element0") == _SireMol.Element("X") or 
                             atom.property("element1") == _SireMol.Element("X")):
 
@@ -1781,7 +1781,7 @@ class Molecule(_SireWrapper):
 
                 # Start bond record.
                 file.write("    bond\n")
-                if pert_type in [
+                if perturbation_type in [
                     "1_discharge_soft",
                     "2_vanish_soft"
                                 ]:
@@ -1793,7 +1793,7 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % 0.0)
                     file.write("        final_equil    %.5f\n" % amber_bond.r0())
 
-                elif pert_type == "3_flip" or pert_type == "standard":
+                elif perturbation_type == "3_flip" or perturbation_type == "standard":
                     # bonds are perturbed.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1802,7 +1802,7 @@ class Molecule(_SireWrapper):
                     file.write("        final_force    %.5f\n" % amber_bond.k())
                     file.write("        final_equil    %.5f\n" % amber_bond.r0())                
 
-                elif pert_type in [
+                elif perturbation_type in [
                     "4_grow_soft",
                     "5_charge_soft"
                                 ]:
@@ -1861,7 +1861,7 @@ class Molecule(_SireWrapper):
 
                         # Start bond record.
                         file.write("    bond\n")
-                        if pert_type in [
+                        if perturbation_type in [
                             "1_discharge_soft",
                             "2_vanish_soft"
                                         ]:
@@ -1872,7 +1872,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_equil  %.5f\n" % amber_bond0.r0())
                             file.write("        final_force    %.5f\n" % amber_bond0.k())
                             file.write("        final_equil    %.5f\n" % amber_bond0.r0())
-                        elif pert_type == "3_flip" or pert_type == "standard":
+                        elif perturbation_type == "3_flip" or perturbation_type == "standard":
                             # Bonds are perturbed.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1880,7 +1880,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_equil  %.5f\n" % amber_bond0.r0())
                             file.write("        final_force    %.5f\n" % amber_bond1.k())
                             file.write("        final_equil    %.5f\n" % amber_bond1.r0())
-                        elif pert_type in [
+                        elif perturbation_type in [
                             "4_grow_soft",
                             "5_charge_soft"
                                         ]:
@@ -1987,7 +1987,7 @@ class Molecule(_SireWrapper):
                 # Start angle record.
                 file.write("    angle\n")
 
-                if pert_type in ["standard", "3_flip"]:
+                if perturbation_type in ["standard", "3_flip"]:
                     # Angle data.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -1996,7 +1996,7 @@ class Molecule(_SireWrapper):
                     file.write("        initial_equil  %.5f\n" % amber_angle.theta0())
                     file.write("        final_force    %.5f\n" % 0.0)
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())
-                elif pert_type in [
+                elif perturbation_type in [
                     "1_discharge_soft",
                     "2_vanish_soft"]:
                     # Angle data, unperturbed.
@@ -2007,7 +2007,7 @@ class Molecule(_SireWrapper):
                     file.write("        initial_equil  %.5f\n" % amber_angle.theta0())
                     file.write("        final_force    %.5f\n" % amber_angle.k())
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())                
-                elif pert_type in [
+                elif perturbation_type in [
                     "4_grow_soft",
                     "5_charge_soft"]:
                     # Angle data, already perturbed.
@@ -2038,7 +2038,7 @@ class Molecule(_SireWrapper):
                 # Start angle record.
                 file.write("    angle\n")
 
-                if pert_type in ["standard", "3_flip"]:
+                if perturbation_type in ["standard", "3_flip"]:
                     # Angle data.
                     file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                     file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2047,7 +2047,7 @@ class Molecule(_SireWrapper):
                     file.write("        initial_equil  %.5f\n" % amber_angle.theta0())
                     file.write("        final_force    %.5f\n" % amber_angle.k())
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())
-                elif pert_type in [
+                elif perturbation_type in [
                     "1_discharge_soft",
                     "2_vanish_soft"]:
                     # Angle data, unperturbed.
@@ -2058,7 +2058,7 @@ class Molecule(_SireWrapper):
                     file.write("        initial_equil  %.5f\n" % amber_angle.theta0())
                     file.write("        final_force    %.5f\n" % 0.0)
                     file.write("        final_equil    %.5f\n" % amber_angle.theta0())                
-                elif pert_type in [
+                elif perturbation_type in [
                     "4_grow_soft",
                     "5_charge_soft"]:
                     # Angle data, already perturbed.
@@ -2117,7 +2117,7 @@ class Molecule(_SireWrapper):
                         # Start angle record.
                         file.write("    angle\n")
                         
-                        if pert_type in ["standard", "3_flip"]:
+                        if perturbation_type in ["standard", "3_flip"]:
                             # Angle data.
                             file.write("        atom0          %s\n" % mol.atom(idx0).name().value())
                             file.write("        atom1          %s\n" % mol.atom(idx1).name().value())
@@ -2126,7 +2126,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_equil  %.5f\n" % amber_angle0.theta0())
                             file.write("        final_force    %.5f\n" % amber_angle1.k())
                             file.write("        final_equil    %.5f\n" % amber_angle1.theta0())
-                        elif pert_type in [
+                        elif perturbation_type in [
                             "1_discharge_soft",
                             "2_vanish_soft"]:
                             # Angle data, unperturbed.
@@ -2137,7 +2137,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_equil  %.5f\n" % amber_angle0.theta0())
                             file.write("        final_force    %.5f\n" % amber_angle0.k())
                             file.write("        final_equil    %.5f\n" % amber_angle0.theta0())             
-                        elif pert_type in [
+                        elif perturbation_type in [
                             "4_grow_soft",
                             "5_charge_soft"]:
                             # Angle data, already perturbed.
@@ -2257,7 +2257,7 @@ class Molecule(_SireWrapper):
                 amber_dihedral_terms_sorted = sorted(
                     amber_dihedral.terms(), key=lambda t: (t.k(), t.periodicity(), t.phase()))
                 for term in amber_dihedral_terms_sorted:
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft",
                         "3_flip",
@@ -2269,7 +2269,7 @@ class Molecule(_SireWrapper):
                 file.write("        final form    ")
 
                 for term in amber_dihedral_terms_sorted:
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
@@ -2307,7 +2307,7 @@ class Molecule(_SireWrapper):
                 amber_dihedral_terms_sorted = sorted(
                     amber_dihedral.terms(), key=lambda t: (t.k(), t.periodicity(), t.phase()))
                 for term in amber_dihedral_terms_sorted:
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft",
                         "3_flip",
@@ -2319,7 +2319,7 @@ class Molecule(_SireWrapper):
                 file.write("\n")
                 file.write("        final_form    ")
                 for term in amber_dihedral_terms_sorted:
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
@@ -2409,7 +2409,7 @@ class Molecule(_SireWrapper):
                             file.write("        initial_form  ")
 
 
-                            if pert_type in ["standard", "3_flip"]:
+                            if perturbation_type in ["standard", "3_flip"]:
                                 # do the standard approach.      
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
@@ -2429,7 +2429,7 @@ class Molecule(_SireWrapper):
                                     file.write(" %5.4f %.1f %7.6f" % (k, term.periodicity(), term.phase()))
                                 file.write("\n")
 
-                            elif pert_type in ["1_discharge_soft", "2_vanish_soft"]:
+                            elif perturbation_type in ["1_discharge_soft", "2_vanish_soft"]:
                                 # Don't perturb dihedrals, i.e. change k1 to k0.
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
@@ -2579,7 +2579,7 @@ class Molecule(_SireWrapper):
                 amber_dihedral_terms_sorted = sorted(
                     amber_dihedral.terms(), key=lambda t: (t.k(), t.periodicity(), t.phase()))
                 for term in amber_dihedral_terms_sorted:
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft",
                         "3_flip",
@@ -2591,7 +2591,7 @@ class Molecule(_SireWrapper):
                 file.write("\n")
                 file.write("        final form    ")
                 for term in amber_dihedral_terms_sorted:
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (term.k(), term.periodicity(), term.phase()))
@@ -2628,7 +2628,7 @@ class Molecule(_SireWrapper):
                 file.write("        initial_form  ")
                 for term in sorted(amber_dihedral0.terms(),
                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft",
                         "3_flip",
@@ -2640,7 +2640,7 @@ class Molecule(_SireWrapper):
                 file.write("        final_form    ")
                 for term in sorted(amber_dihedral1.terms(),
                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
-                    if pert_type in [
+                    if perturbation_type in [
                         "1_discharge_soft",
                         "2_vanish_soft"]:
                         file.write(" %5.4f %.1f %7.6f" % (0.0, term.periodicity(), term.phase()))
@@ -2726,7 +2726,7 @@ class Molecule(_SireWrapper):
                             file.write("        atom3          %s\n" % mol.atom(idx3).name().value())
                             file.write("        initial_form  ")
 
-                            if pert_type in ["standard", "3_flip"]:
+                            if perturbation_type in ["standard", "3_flip"]:
                                 # do the standard approach.      
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):
@@ -2746,7 +2746,7 @@ class Molecule(_SireWrapper):
                                     file.write(" %5.4f %.1f %7.6f" % (k, term.periodicity(), term.phase()))
                                 file.write("\n")
 
-                            elif pert_type in ["1_discharge_soft", "2_vanish_soft"]:
+                            elif perturbation_type in ["1_discharge_soft", "2_vanish_soft"]:
                                 # Don't perturb dihedrals, i.e. change k1 to k0.
                                 for term in sorted(amber_dihedral0.terms(),
                                                    key=lambda t: (t.k(), t.periodicity(), t.phase())):


### PR DESCRIPTION
This PR relates to #165.

This is a first implementation of the multi-step protocol; with this it is now possible for the user to define a `pert_type` in `BSS.Protocol.FreeEnergy()`. If not defined, the setup will default to a normal FEP setup (i.e. 1 step). I've built it into Protocol because it gives users the freedom to define specific numbers of lambda windows per step.

There are several caveats to the current implementation:
- when building multiple steps, `BSS.Protocol.FreeEnergy()` will have to be called multiple times. For instance:
```
# set up step 1.
protocol = BSS.Protocol.FreeEnergy(num_lam=10, pert_type="1_discharge_soft")
BSS.FreeEnergy.Solvation(system_solvated, protocol, work_dir="output/1_discharge_soft")

# set up step 2.
protocol = BSS.Protocol.FreeEnergy(num_lam=15, pert_type="2_vanish_soft")
BSS.FreeEnergy.Solvation(system_solvated, protocol, work_dir="output/2_vanish_soft")

# etc.
```
- Currently for a given perturbation BSS will setup whichever step is specified. When (e.g.) a perturbation only consists of **growing** atoms, two of the five steps are redundant (.pert files of `1_discharge_soft` and `2_vanish_soft` contain no changes). At the moment it is up to the user to take this into account: either by knowing which perturbations are grow/shrink/both and to setup specific steps accordingly, or by removing redundant step folders by e.g. checking if the .pert files contain changes. Implementing something like this in BSS might be quite complex.
- `freenrg.analyse()` will only compute the free energy for a given step and not the sum of steps. 
