### PR TITLE
Update _io.py

### DIFF
--- a/python/BioSimSpace/IO/_io.py
+++ b/python/BioSimSpace/IO/_io.py
@@ -754,10 +754,25 @@ def readPerturbableSystem(coords, top0, top1, property_map={}):
             raise IOError(msg) from e
         else:
             raise IOError(msg) from None
-    parser = _SireIO.AmberPrm(top0)
+    try:
+        parser = _SireIO.AmberPrm(top0)
+    except Exception as e:
+        msg = f"Unable to read lambda=0 topology file: {top0}"
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None
     if parser.isEmpty():
         raise ValueError(f"Unable to read topology file for lamba=0 end state: {top0}")
-    parser = _SireIO.AmberPrm(top1)
+
+    try:
+        parser = _SireIO.AmberPrm(top1)
+    except Exception as e:
+        msg = f"Unable to read lambda=1 topology file: {top1}"
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None
     if parser.isEmpty():
         raise ValueError(f"Unable to read topology file for lamba=1 end state: {top1}")
 


### PR DESCRIPTION
Sanity check for topology parser. 

I accidentally passed a wrong file path for the topology file, a lot of error messages were printed. It might be better if it could be caught at the python level. 

Here is part of the error message: 
```
Traceback (most recent call last):                                                                
  File "/root/group_ceph/FEP/prepare/test_prepare_system.py", line 83, in <module>                
    test_load()                                                                                   
  File "/root/group_ceph/FEP/prepare/test_prepare_system.py", line 41, in test_load               
    moprh = BSS.IO.readPerturbableSystem(rst, prm0, prm1)                                         
  File "/root/group_ceph/FEP/prepare/BioSimSpace/IO/_io.py", line 757, in readPerturbableSystem   
    parser = _SireIO.AmberPrm(top0)                                                               
UserWarning: Exception 'SireError::file_error' thrown by the thread 'master'.
The file "/root/group_ceph/FEP/prepare/data/YU10_0/SYSTEM/Perturbations/smile187~smile201/smile187
~smile2012.prm7" could not be opened.
Thrown from FILE: /home/sireuser/Sire/corelib/src/libs/SireIO/moleculeparser.cpp, LINE: 497, FUNCT
ION: static QVector<QString> SireIO::MoleculeParser::readTextFile(QString)
__Backtrace__
(  0) /data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/Qt/../../../../../lib/libSireErro
r.so.2021 ([0x7f14e80b8c1e] ++0x2e)
  -- SireError::getBackTrace()

(  1) /data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/Qt/../../../../../lib/libSireErro
r.so.2021 ([0x7f14e80b5a0e] ++0x7e)
  -- SireError::exception::exception(QString, QString)

/data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/IO/../../../../../lib/libSireIO.so.2021
(+0xa1bef) [0x7f14e3924bef]
(  3) /data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/IO/../../../../../lib/libSireIO.s
o.2021 ([0x7f14e3a9082d] ++0x5cd)
  -- SireIO::MoleculeParser::readTextFile(QString)

(  4) /data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/IO/../../../../../lib/libSireIO.s
o.2021 ([0x7f14e3a90af2] ++0xc2)
  -- SireIO::MoleculeParser::MoleculeParser(QString const&, SireBase::PropertyMap const&)

(  5) /data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/IO/../../../../../lib/libSireIO.s
o.2021 ([0x7f14e39593c6] ++0x16)
  -- SireIO::AmberPrm::AmberPrm(QString const&, SireBase::PropertyMap const&)

/data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/IO/_IO.so(+0xede54) [0x7f14e3ccce54]
/data/miniconda3/envs/uii/lib/python3.7/site-packages/Sire/IO/_IO.so(+0x8da12) [0x7f14e3c6ca12]
```