### PR TITLE
added UpdatePropertyCache() call to resolve depiction bug

### DIFF
--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -337,6 +337,7 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
         # 3) Load all ligands, make 2D depiction aligned to the template and save to file.
         try:
             for x, mol in enumerate(rdmols):
+                mol.UpdatePropertyCache(strict=False)
                 _AllChem.Compute2DCoords(mol)
                 _AllChem.GenerateDepictionMatching2DStructure(mol, template)
 


### PR DESCRIPTION
this fixes a small bug that I was having while generating FEP networks for the CDK2 benchmarking series of ligands. The UpdatePropertyCache() call takes care of valency issues in the input file.