### PR TITLE
Lomap improvements

### DIFF
--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -329,7 +329,13 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
             # remove hydrogens to dramatically speed up MCS algorithm.
             rdmols = [_Chem.RemoveHs(mol) for mol in rdmols]
 
-            template = _Chem.MolFromSmarts(_rdFMCS.FindMCS(rdmols).smartsString)
+            template = _Chem.MolFromSmarts(_rdFMCS.FindMCS(rdmols,
+                                    atomCompare=_rdFMCS.AtomCompare.CompareAny,
+                                    bondCompare=_rdFMCS.BondCompare.CompareAny,
+                                    matchValences=False,
+                                    ringMatchesRingOnly=True,
+                                    completeRingsOnly=True,
+                                    matchChiralTag=False).smartsString)
             _AllChem.Compute2DCoords(template)
 
         except Exception as e:


### PR DESCRIPTION
did some work on speeding up the LOMAP code because I've been working with series that have 1) large molecules and 2) a large number of molecules per series (>25). 
- LOMAP now runs on 10 processes instead of 1
- LOMAP internal MCS timeout is set to 3 seconds (instead of 360 sec rdkit default [sorry for that commit, I first thought there was no default time limit]) which should be more than enough for any drug-like MCS. Particularly this issue rendered LOMAP useless for larger series as for each network generation MCS is run on all possible pairs.

I also cleaned up the ligand depiction in the network so that we don't have messy carbon notations anymore. This was achieved by 
- removing hydrogens from the core (to which ligands are aligned) --> actually speeds up the MCS algorithm considerably as well
- removing stereochemistry from ligands before plotting (this isn't very relevant when viewing FEP networks)

making ligands look like: 
![image](https://user-images.githubusercontent.com/43140137/137472347-40ea404e-d3d1-45e1-839e-9428a69de2d2.png)


instead of:
![image](https://user-images.githubusercontent.com/43140137/137472070-6853a486-9efb-4638-8344-a7c9ea888003.png)
