### PR TITLE
Addded support for streaming wrapped Sire objects

### DIFF
--- a/doc/source/api/index_Box.rst
+++ b/doc/source/api/index_Box.rst
@@ -1,7 +1,7 @@
 .. _ref-Box:
 
 BioSimSpace.Box
-===================
+===============
 
 The *Box* package contains tools for generating parameters for different
 simulation boxes. This is particularly useful when needing box magnitudes and

--- a/doc/source/api/index_Stream.rst
+++ b/doc/source/api/index_Stream.rst
@@ -1,0 +1,12 @@
+.. _ref-Stream:
+
+BioSimSpace.Stream
+==================
+
+The *Stream* package contains tools for streaming wrapped Sire objects to and
+from binary file.
+
+.. automodule:: BioSimSpace.Stream
+
+.. toctree::
+   :maxdepth: 1

--- a/doc/source/api/index_Stream.rst
+++ b/doc/source/api/index_Stream.rst
@@ -3,8 +3,8 @@
 BioSimSpace.Stream
 ==================
 
-The *Stream* package contains tools for streaming wrapped Sire objects to and
-from binary file.
+The *Stream* package contains tools for streaming wrapped Sire objects, i.e.
+objects from :ref:`ref-SireWrappers`.
 
 .. automodule:: BioSimSpace.Stream
 

--- a/python/BioSimSpace/Stream/__init__.py
+++ b/python/BioSimSpace/Stream/__init__.py
@@ -30,6 +30,28 @@ Functions
 
     save
     load
+
+Examples
+========
+
+Stream a :class:`System <BioSimSpace._SireWrappers.System>` object to and from
+file.
+
+.. code-block:: python
+
+   import BioSimSpace as BSS
+
+   # Load a molecule system.
+   system0 = BSS.IO.readMolecules(["ala.rst7", "ala.prm7"])
+
+   # Stream to file.
+   BSS.Stream.save(system0, "system")
+
+   # Alternatively, stream the system object directly.
+   system0.save("system")
+
+   # Stream from file.
+   system1 = BSS.Stream.load("system.s3")
 """
 
 from ._stream import *

--- a/python/BioSimSpace/Stream/__init__.py
+++ b/python/BioSimSpace/Stream/__init__.py
@@ -1,0 +1,35 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2021
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""
+.. currentmodule:: BioSimSpace.Stream
+
+Functions
+=========
+
+.. autosummary::
+    :toctree: generated/
+
+    save
+    load
+"""
+
+from ._stream import *

--- a/python/BioSimSpace/Stream/_stream.py
+++ b/python/BioSimSpace/Stream/_stream.py
@@ -1,0 +1,115 @@
+######################################################################
+# BioSimSpace: Making biomolecular simulation a breeze!
+#
+# Copyright: 2017-2021
+#
+# Authors: Lester Hedges <lester.hedges@gmail.com>
+#
+# BioSimSpace is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# BioSimSpace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BioSimSpace. If not, see <http://www.gnu.org/licenses/>.
+#####################################################################
+
+"""
+Functionality for streaming wrapped Sire objects.
+"""
+
+__author__ = "Lester Hedges"
+__email__  = "lester.hedges@gmail.com"
+
+__all__ = ["save", "load"]
+
+import os as _os
+
+from Sire import Mol as _SireMol
+from Sire import Stream as _SireStream
+from Sire import System as _SireSystem
+
+from BioSimSpace import _isVerbose
+from BioSimSpace._Exceptions import StreamError as _StreamError
+from BioSimSpace._SireWrappers._sire_wrapper import SireWrapper as _SireWrapper
+from BioSimSpace import _SireWrappers
+
+def save(sire_object, filebase):
+    """Stream a wrapped Sire object to file.
+
+       Parameters
+       ----------
+
+       sire_object : :class:`System <BioSimSpace._SireWrappers.SireWrapper>`
+           A wrapped Sire object.
+
+       filebase : str
+           The base name of the binary output file.
+    """
+
+    # Validate input.
+
+    if not isinstance(sire_object, _SireWrapper) and \
+       not isinstance(sire_object, _SireWrappers.SearchResult):
+        raise TypeError("'sire_object' must be of type 'BioSimSpace._SireWrappers.SireWrapper'.")
+
+    if type(filebase) is not str:
+        raise TypeError("'filebase' must be of type 'str'.")
+
+    try:
+        _SireStream.save(sire_object._sire_object, f"{filebase}.s3")
+    except Exception as e:
+        msg = f"Failed to stream {sire_object} to file '{filebase}.s3'."
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None
+
+def load(file):
+    """Stream a wrapped Sire object from file.
+
+       Parameters
+       ----------
+
+       file : str
+           The path to the binary file containing the streamed object.
+    """
+
+    # Validate input.
+
+    if not _os.path.isfile(file):
+        raise TypeError(f"The binary file '{file}' doesn't exist!")
+
+    # Try to load the object.
+
+    try:
+        # Stream from file.
+        sire_object = _SireStream.load(file)
+
+        # Construct the wrapped object.
+        if isinstance(sire_object, _SireSystem.System):
+            return _SireWrappers.System(sire_object)
+        elif isinstance(sire_object, _SireMol.Molecule):
+            return _SireWrappers.Molecule(sire_object)
+        elif isinstance(sire_object, _SireMol.MoleculeGroup):
+            return _SireWrappers.Molecules(sire_object)
+        elif isinstance(sire_object, _SireMol.Residue):
+            return _SireWrappers.Residue(sire_object)
+        elif isinstance(sire_object, _SireMol.Atom):
+            return _SireWrappers.Atom(sire_object)
+        elif isinstance(sire_object, _SireMol.SelectResult):
+            return _SireWrappers.SearchResult(sire_object)
+        else:
+            raise _StreamError(f"Unable to stream object of type {type(sire_object)}.")
+
+    except Exception as e:
+        msg = f"Failed to stream {object} from file '{file}'."
+        if _isVerbose():
+            raise IOError(msg) from e
+        else:
+            raise IOError(msg) from None

--- a/python/BioSimSpace/_Exceptions/_exceptions.py
+++ b/python/BioSimSpace/_Exceptions/_exceptions.py
@@ -31,6 +31,7 @@ __all__ = ["AlignmentError",
            "IncompatibleError",
            "MissingSoftwareError",
            "ParameterisationError",
+           "StreamError",
            "ThirdPartyError"]
 
 class AlignmentError(Exception):
@@ -50,6 +51,10 @@ class MissingSoftwareError(Exception):
 
 class ParameterisationError(Exception):
     """Exception thrown when molecular parameterisation fails."""
+    pass
+
+class StreamError(Exception):
+    """Exception thrown when streaming fails."""
     pass
 
 class ThirdPartyError(Exception):

--- a/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
+++ b/python/BioSimSpace/_SireWrappers/_sire_wrapper.py
@@ -243,6 +243,20 @@ class SireWrapper():
 
         return box_min, box_max
 
+    def save(self, filebase):
+        """Stream a wrapped Sire object to file.
+
+           Parameters
+           ----------
+
+           sire_object : :class:`System <BioSimSpace._SireWrappers.SireWrapper>`
+               A wrapped Sire object.
+
+           filebase : str
+               The base name of the binary output file.
+        """
+        _save(self, filebase)
+
     def _getSireObject(self):
         """Return the underlying Sire object.
 
@@ -305,3 +319,6 @@ class SireWrapper():
 
         # Return the AABox for the coordinates.
         return _SireVol.AABox(coord)
+
+# Import at bottom of module to avoid circular dependency.
+from BioSimSpace.Stream import save as _save

--- a/python/BioSimSpace/__init__.py
+++ b/python/BioSimSpace/__init__.py
@@ -44,6 +44,7 @@ __all__ = ["Align",
            "Process",
            "Protocol",
            "Solvent",
+           "Stream",
            "Trajectory",
            "Types",
            "Units"]
@@ -199,6 +200,7 @@ from . import Parameters
 from . import Process
 from . import Protocol
 from . import Solvent
+from . import Stream
 from . import Trajectory
 from . import Types
 from . import Units

--- a/test/Stream/test_stream.py
+++ b/test/Stream/test_stream.py
@@ -1,0 +1,129 @@
+import BioSimSpace as BSS
+
+import os
+import pytest
+
+@pytest.fixture
+def system():
+    return BSS.IO.readMolecules("test/io/amber/ala/*")
+
+def test_system(system):
+    """Test streaming of a Sire system."""
+
+    # Stream to file.
+    BSS.Stream.save(system, "test")
+
+    # Stream from file.
+    s = BSS.Stream.load("test.s3")
+
+    # Check that both systems contain the same number of molecules.
+    assert system.nMolecules() == s.nMolecules()
+
+    # Check that the molecules in both systems contain the same number
+    # of residues and atoms.
+    for m0, m1 in zip(system, s):
+        assert m0.nResidues() == m1.nResidues()
+        assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+def test_molecule(system):
+    """Test streaming of a Sire molecule."""
+
+    # Extract the first molecule.
+    m0 = system[0]
+
+    # Stream to file.
+    BSS.Stream.save(m0, "test")
+
+    # Stream from file.
+    m1 = BSS.Stream.load("test.s3")
+
+    # Check that the molecules contain the same number of residues and atoms.
+    assert m0.nResidues() == m1.nResidues()
+    assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+def test_molecules(system):
+    """Test streaming of a Sire molecule group."""
+
+    # Stream to file.
+    BSS.Stream.save(system.getMolecules(), "test")
+
+    # Stream from file.
+    m = BSS.Stream.load("test.s3")
+
+    # Check that the system contain the same number of molecules as the
+    # molecule group.
+    assert system.nMolecules() == len(m)
+
+    # Check that the molecules in the system and molecule group contain the
+    # same number of residues and atoms.
+    for m0, m1 in zip(system, m):
+        assert m0.nResidues() == m1.nResidues()
+        assert m0.nAtoms() == m1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+def test_residue(system):
+    """Test streaming of a Sire residue."""
+
+    # Extract the first residue of the first molecule.
+    r0 = system[0].getResidues()[0]
+
+    # Stream to file.
+    BSS.Stream.save(r0, "test")
+
+    # Stream from file.
+    r1 = BSS.Stream.load("test.s3")
+
+    # Check that the residues contain the same number of atoms.
+    assert r0.nAtoms() == r1.nAtoms()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+def test_atom(system):
+    """Test streaming of a Sire atom."""
+
+    # Extract the first atom of the first molecule.
+    a0 = system[0].getAtoms()[0]
+
+    # Stream to file.
+    BSS.Stream.save(a0, "test")
+
+    # Stream from file.
+    a1 = BSS.Stream.load("test.s3")
+
+    # Check that the atom elements are the same.
+    assert a0.element() == a1.element()
+
+    # Remove the test file.
+    os.remove("test.s3")
+
+def test_select_result(system):
+    """Test streaming of a Sire select result."""
+
+    # Search for all carbon atoms.
+    s0 = system.search("element C")
+
+    # Stream to file.
+    BSS.Stream.save(s0, "test")
+
+    # Stream from file.
+    s1 = BSS.Stream.load("test.s3")
+
+    # Check that the number of search results is the same.
+    assert s0.nResults() == s1.nResults()
+
+    # Check that the results have the same element and index.
+    for a0, a1 in zip(s0, s1):
+        assert a0.index() == a1.index()
+        assert a0.element() == a1.element()
+
+    # Remove the test file.
+    os.remove("test.s3")


### PR DESCRIPTION
This pull request adds long overdue support for streaming wrapped Sire objects, i.e. the objects from [BioSimSpace._SireWrappers](https://biosimspace.org/api/index_SireWrappers.html). This facilitates the streaming of systems containing perturbable molecules and _should_ make it easier to pass information between BioSimSpace nodes. This also opens the possibility of stream support for complex objects that contain a mixture of pure Python attributes and wrapped Sire objects, i.e. the Python attributes could be pickled separately as a dictionary or dataclass, while the wrapped Sire object is streamed. These could be streamed back from file independently, then recombined.