### PR TITLE
Lomap improvements again

### DIFF
--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -155,7 +155,6 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
     # A list of RDKit molecule objects.
     elif all(isinstance(x, _Chem.rdchem.Mol) for x in molecules):
         rdkit_input = True
-
     else:
         raise TypeError("'molecules' must be a list of "
                         "'BioSimSpace._SireWrappers.Molecule' "

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -235,17 +235,15 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
     _os.makedirs(work_dir + "/outputs", exist_ok=True)
 
     # Write all of the molecules to disk.
-    if not rdkit_input:
-      for x, (molecule, name) in enumerate(zip(molecules, names)):
-          _IO.saveMolecules(work_dir + f"/inputs/{x:03d}_{name}",
-              molecule, "mol2", property_map=property_map)
-
-    elif rdkit_input:
-      for x, (molecule, name) in enumerate(zip(molecules, names)):
-          writer =  _Chem.SDWriter(work_dir + f"/inputs/{x:03d}_{name}.sdf")
-          writer.write(molecule)
-          writer.close()
-
+    if rdkit_input:
+        for x, (molecule, name) in enumerate(zip(molecules, names)):
+            writer =  _Chem.SDWriter(work_dir + f"/inputs/{x:03d}_{name}.sdf")
+            writer.write(molecule)
+            writer.close()
+    else:
+        for x, (molecule, name) in enumerate(zip(molecules, names)):
+            _IO.saveMolecules(work_dir + f"/inputs/{x:03d}_{name}",
+                molecule, "mol2", property_map=property_map)
 
     # Create a local copy of the links file in the working directory.
     # This isn't needed, but is useful for debugging and ensuring that
@@ -329,14 +327,14 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
         # 1) Loop over each molecule and load into RDKit.
         try:
-          rdmols = []
-          for x, name in zip(range(0, len(molecules)), names):
-              try:
+        rdmols = []
+            for x, name in zip(range(0, len(molecules)), names):
+                try:
                 file = f"{work_dir}/inputs/{x:03d}_{name}.mol2"
                 rdmols.append(_Chem.rdmolfiles.MolFromMol2File(file, sanitize=False, removeHs=False))
-              except OSError:
-                file = f"{work_dir}/inputs/{x:03d}_{name}.sdf"
-                rdmols.append(_Chem.SDMolSupplier(file, sanitize=False, removeHs=False)[0])
+        except OSError:
+            file = f"{work_dir}/inputs/{x:03d}_{name}.sdf"
+            rdmols.append(_Chem.SDMolSupplier(file, sanitize=False, removeHs=False)[0])
 
         except Exception as e:
             msg = "Unable to load molecule into RDKit!"

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -149,14 +149,17 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
     rdkit_input = False
     _Molecule_rdkit = type(_Chem.MolFromSmiles("c1ccccc1"))
 
-    if not all(isinstance(x, _Molecule) for x in molecules):
-      if not all(isinstance(x, _Molecule_rdkit) for x in molecules):
-          raise TypeError("'molecules' must be a list of "
-                          "'BioSimSpace._SireWrappers.Molecule' "
-                          "or 'rdkit.Chem.rdchem.Mol' objects.")
-
-      elif all(isinstance(x, _Molecule_rdkit) for x in molecules):
+    # A list of BioSimSpace molecule objects.
+    if all(isinstance(x, _Molecule) for x in molecules):
+        pass
+    # A list of RDKit molecule objects.
+    elif all(isinstance(x, _Chem.rdchem.Mol) for x in molecules):
         rdkit_input = True
+
+    else:
+        raise TypeError("'molecules' must be a list of "
+                        "'BioSimSpace._SireWrappers.Molecule' "
+                        "or 'rdkit.Chem.rdchem.Mol' objects.")
 
     # Validate the names.
     if names is not None:

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -336,7 +336,7 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
                 rdmols.append(_Chem.rdmolfiles.MolFromMol2File(file, sanitize=False, removeHs=False))
               except OSError:
                 file = f"{work_dir}/inputs/{x:03d}_{name}.sdf"
-                rdmols.append(_Chem.SDMolSupplier(file, sanitize=False, removeHs=False)[0])                
+                rdmols.append(_Chem.SDMolSupplier(file, sanitize=False, removeHs=False)[0])
 
         except Exception as e:
             msg = "Unable to load molecule into RDKit!"

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -423,19 +423,19 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
         # 5) Create and display the plot.
         try:
-          # Convert to a dot graph.
-          dot_graph = _nx.drawing.nx_pydot.to_pydot(graph)
+            # Convert to a dot graph.
+            dot_graph = _nx.drawing.nx_pydot.to_pydot(graph)
 
-          # Write to a PNG.
-          network_plot = f"{work_dir}/images/network.png"
-          dot_graph.write_png(network_plot)
+            # Write to a PNG.
+            network_plot = f"{work_dir}/images/network.png"
+            dot_graph.write_png(network_plot)
 
-          if _is_notebook:
-            # Create a plot of the network.
-            img = _mpimg.imread(network_plot)
-            _plt.figure(figsize=(20, 20))
-            _plt.axis("off")
-            _plt.imshow(img)
+            if _is_notebook:
+                # Create a plot of the network.
+                img = _mpimg.imread(network_plot)
+                _plt.figure(figsize=(20, 20))
+                _plt.axis("off")
+                _plt.imshow(img)
 
         except Exception as e:
             msg = "Unable to create network plot!"
@@ -444,6 +444,7 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
                 raise _AlignmentError(msg) from e
             else:
                 raise _AlignmentError(msg) from None
+
     return edges, scores
 
 def matchAtoms(molecule0,

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -86,9 +86,10 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
        Parameters
        ----------
 
-       molecules : :[class:`Molecule <BioSimSpace._SireWrappers.Molecule>`] OR
-                    [class:`rdkit.Chem.rdchem.Mol`]
-           A list of molecules.
+       molecules : :[class:`Molecule <BioSimSpace._SireWrappers.Molecule>`],
+                    [rdkit.Chem.rdchem.Mol]
+           A list of molecules. (Both BioSimSpace and RDKit molecule objects
+           are supported.)
 
        names : [str]
            A list of names for the molecules. If None, then the index of each

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -330,14 +330,14 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
         # 1) Loop over each molecule and load into RDKit.
         try:
-        rdmols = []
+            rdmols = []
             for x, name in zip(range(0, len(molecules)), names):
                 try:
-                file = f"{work_dir}/inputs/{x:03d}_{name}.mol2"
-                rdmols.append(_Chem.rdmolfiles.MolFromMol2File(file, sanitize=False, removeHs=False))
-        except OSError:
-            file = f"{work_dir}/inputs/{x:03d}_{name}.sdf"
-            rdmols.append(_Chem.SDMolSupplier(file, sanitize=False, removeHs=False)[0])
+                    file = f"{work_dir}/inputs/{x:03d}_{name}.mol2"
+                    rdmols.append(_Chem.rdmolfiles.MolFromMol2File(file, sanitize=False, removeHs=False))
+                except OSError:
+                    file = f"{work_dir}/inputs/{x:03d}_{name}.sdf"
+                    rdmols.append(_Chem.SDMolSupplier(file, sanitize=False, removeHs=False)[0])
 
         except Exception as e:
             msg = "Unable to load molecule into RDKit!"

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -147,7 +147,6 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
     # Validate the molecules.
     rdkit_input = False
-    _Molecule_rdkit = type(_Chem.MolFromSmiles("c1ccccc1"))
 
     # A list of BioSimSpace molecule objects.
     if all(isinstance(x, _Molecule) for x in molecules):


### PR DESCRIPTION
some more tweaks to `generateNetwork()` that were necessary for my work. 

1) `molecules` can now also be passed as a list of RDKit molecules instead of BSS molecules. In this case, the intermediate ligand files written to `work_dir` are SDF. The reason for this is that for ~60% of test cases (FEP congeneric series), RDKit kekulization fails when using MOL2 inputs, i.e. making LOMAP fail. See some other discussions: https://github.com/MobleyLab/Lomap/issues/26 and https://sourceforge.net/p/rdkit/mailman/message/35999854/
Using an SDF intermediate makes all molecules pass; presumably this is what Cresset is doing as well (see Max's comment in the linked LOMAP issue).
2) I'm generating a large number of networks for many different series and I want to compare networks after letting my code run for a few days, so I have a use-case where I want to write network plots outside of a notebook. This PR changes `generateNetwork()` such that it writes the plot file to `work_dir` even when not in a notebook - if in a notebook, the plot it still shown.

I realise that these types of PRs are not very sustainable wrt ongoing work over at Mobley et al; perhaps all my PRs here are making our implementation too convoluted? I'm not sure who else even uses our current LOMAP implementation.. Anyway, this is just for posterity, if you'd rather I fork my own I'd be happy to do that too instead.