### PR TITLE
Feature lomap force n edges

### DIFF
--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -80,7 +80,7 @@ except:
     _fkcombu_exe = None
 
 def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
-        links_file=None, property_map={}):
+        links_file=None, property_map={}, n_edges_forced=None):
     """Generate a perturbation network using Lead Optimisation Mappper (LOMAP).
 
        Parameters
@@ -122,6 +122,17 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
            A dictionary that maps "properties" in molecule0 to their user
            defined values. This allows the user to refer to properties
            with their own naming scheme, e.g. { "charge" : "my-charge" }
+
+       n_edges_forced : int
+           A string that forces the number of edges that should be used in
+           the perturbation network. Must be in the range 
+           [1 .. (len(molecules)**2-len(molecules))/2]. 
+           In cases where n_edges_forced > the number of edges suggested by 
+           LOMAP, BSS will add the top scoring n edges parsed from the LOMAP 
+           output file and add them to the network. Conversely if 
+           n_edges_forced < the number of edges suggested by LOMAP, BSS will 
+           remove the bottom n edges parsed from the LOMAP output file.
+
 
        Returns
        -------
@@ -215,6 +226,15 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
         else:
             raise IOError(f"The links file doesn't exist: {links_file}")
+
+    # Validate the number of edges parameter.
+    if type(n_edges_forced) is not int:
+    	raise TypeError("'n_edges_forced' must be of type 'int'")
+
+    n_edges_fully_connected = int((len(molecules)**2 - len(molecules))/2)+1
+
+    if not 0 < n_edges_forced < n_edges_fully_connected:
+    	raise ValueError(f"'n_edges_forced' must be 0 < value < {n_edges_fully_connected}.")
 
     # Create a temporary working directory and store the directory name.
     if work_dir is None:

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -124,7 +124,7 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
            with their own naming scheme, e.g. { "charge" : "my-charge" }
 
        n_edges_forced : int
-           A string that forces the number of edges that should be used in
+           An integer that forces the number of edges that should be used in
            the perturbation network. Must be in the range 
            [1 .. (len(molecules)**2-len(molecules))/2]. 
            In cases where n_edges_forced > the number of edges suggested by 

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -125,16 +125,15 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
        n_edges_forced : int
            An integer that forces the number of edges that should be used in
-           the perturbation network. Must be in the range 
-           [1 .. (len(molecules)**2-len(molecules))/2]. 
-           In cases where n_edges_forced > the number of edges suggested by 
-           LOMAP, BSS will add the top scoring n edges parsed from the LOMAP 
-           output file and add them to the network. Conversely if 
-           n_edges_forced < the number of edges suggested by LOMAP, BSS will 
-           remove the bottom n edges parsed from the LOMAP output file. This 
-           last option is discouraged as it can cause network cycle breakage 
-           and disconnecting of ligands/clusters from the network.
-
+           the perturbation network. Must be in the range
+           [1 .. (len(molecules)**2-len(molecules))/2].
+           In cases where n_edges_forced > the number of edges suggested by
+           LOMAP, BioSimSpace will add the top scoring n edges parsed from the
+           LOMAP output file and add them to the network. Conversely if
+           n_edges_forced < the number of edges suggested by LOMAP, BioSimSpace
+           will remove the bottom n edges parsed from the LOMAP output file.
+           This last option is discouraged as it can cause network cycle
+           breakage and disconnecting of ligands/clusters from the network.
 
        Returns
        -------
@@ -332,7 +331,7 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
                 nodes.append(mol1)
                 scores.append(score)
 
-            # also collect the excluded edges in case we need to add more at a later stage.
+            # Also collect the excluded edges in case we need to add more at a later stage.
             elif row[7].strip() == "No":
                 # Extract the nodes (molecules) connected by the edge.
                 mol0 = int(row[2].rsplit(".")[0].rsplit("_")[0])
@@ -341,19 +340,19 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
                 # Extract the score and convert to a float.
                 score = float(row[4])
 
-                # Update the list while checking that the inverse edge is not already in 
+                # Update the list while checking that the inverse edge is not already in
                 # the network.
                 if not (mol1, mol0) in edges:
                     edges_excluded.append((mol0, mol1, score))
 
-    # If the user has specified a forced number of edges, adjust the network 
+    # If the user has specified a forced number of edges, adjust the network
     # to match the query. We have three situations to deal with.
     if n_edges_forced:
 
         # sort the list of excluded edges by LOMAP score.
         edges_excluded.sort(key=lambda x: x[2], reverse=True)
 
-        # 1) The network already contains the specified number of edges. 
+        # 1) The network already contains the specified number of edges.
         if  len(edges) == n_edges_forced:
             # Return the network as is.
             print(f"LOMAP already suggested the user-specified number of edges ({len(edges)}).")
@@ -364,14 +363,14 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
             n_to_add = n_edges_forced-len(edges)
             print(f"Adding {n_to_add} edges to the LOMAP network.")
 
-            # get the top n excluded edges.
+            # Get the top n excluded edges.
             for edge in edges_excluded[:n_to_add]:
                 edges.append((edge[0], edge[1]))
                 nodes.append(edge[0])
                 nodes.append(edge[1])
-                scores.append(edge[2])                
+                scores.append(edge[2])
 
-        # 3) The network contains more edges than the specified number. This is not 
+        # 3) The network contains more edges than the specified number. This is not
         # recommended as this can cause breaking of network cycles or disconnecting nodes.
         elif len(edges) > n_edges_forced:
             # We need to remove edges from the network to match the queried number.
@@ -380,10 +379,10 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
                 +" breaking network cycles or disconnecting ligands/ clusters.")
             lomap_network = list(zip(edges, scores))
 
-            # sort the network by LOMAP-score.
+            # Sort the network by LOMAP-score.
             lomap_network.sort(key=lambda x: x[1])
 
-            # create the new network by keeping the required number of top edges.
+            # Create the new network by keeping the required number of top edges.
             edges = []
             nodes = []
             scores = []
@@ -392,7 +391,6 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
                 nodes.append(edge[0][0])
                 nodes.append(edge[0][1])
                 scores.append(edge[1])
-
 
     # Convert nodes to a set to remove duplicates.
     nodes = set(nodes)

--- a/python/BioSimSpace/Align/_align.py
+++ b/python/BioSimSpace/Align/_align.py
@@ -229,12 +229,12 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
 
     # Validate the number of edges parameter.
     if type(n_edges_forced) is not int:
-    	raise TypeError("'n_edges_forced' must be of type 'int'")
+        raise TypeError("'n_edges_forced' must be of type 'int'")
 
     n_edges_fully_connected = int((len(molecules)**2 - len(molecules))/2)+1
 
     if not 0 < n_edges_forced < n_edges_fully_connected:
-    	raise ValueError(f"'n_edges_forced' must be 0 < value < {n_edges_fully_connected}.")
+        raise ValueError(f"'n_edges_forced' must be 0 < value < {n_edges_fully_connected}.")
 
     # Create a temporary working directory and store the directory name.
     if work_dir is None:
@@ -325,6 +325,23 @@ def generateNetwork(molecules, names=None, work_dir=None, plot_network=False,
                 nodes.append(mol0)
                 nodes.append(mol1)
                 scores.append(score)
+
+        # if the user has specified a forced number of edges, adjust the network 
+        # to match the query. We have three situations to deal with.
+        if n_edges_forced:
+
+            # 1) the network already contains the specified number. 
+            if  len(edges) == n_edges_forced:
+                pass
+
+            # 2) the network contains fewer than the specfied number.
+            elif len(edges) < n_edges_forced:
+                pass
+
+            # 3) the network contains more than the specified number.
+            elif len(edges) > n_edges_forced:
+                pass
+
 
     # Convert nodes to a set to remove duplicates.
     nodes = set(nodes)

--- a/python/BioSimSpace/Align/_lomap/dbmol.py
+++ b/python/BioSimSpace/Align/_lomap/dbmol.py
@@ -405,7 +405,7 @@ class DBMolecules(object):
                         score = -score
                     self.prespecified_links[(indexa,indexb)]=score
                     self.prespecified_links[(indexb,indexa)]=score
-                    print("Added prespecified link for mols",mols,"->",(indexa,indexb),"score",score)
+                    logging.info("Added prespecified link for mols",mols,"->",(indexa,indexb),"score",score)
         except KeyError as e:
             raise IOError('Filename within the links file "'+links_file+'" not found: '+str(e)) from None
 


### PR DESCRIPTION
this PR adds functionality to `BSS.Align._align.generateNetwork()` such that it now ingests a user-specified integer (`n_edges_forced`) that forces the number of edges included in the perturbation network. This is useful for general practice as typically FEP campaigns have a pre-set amount of compute available. It also allows direct comparison between networks generated with different types of inputs (i.e. beside LOMAP-Score using the `links_file`).

I have included validation (checks that `n_edges_forced` is an _int_ and checks that it is higher than 0 and at most a fully-connected network.

There are three situations as described in the code:
1. the user-specified number of edges is already suggested by LOMAP, in this case do nothing.
2. the user-specified number of edges is higher than in the LOMAP network; in this case add n top-scoring edges parsed from the LOMAP output file.
3.  the user-specified number of edges is lower than in the LOMAP network; in this case remove n lowest scoring edges from the suggested network. This situation is discouraged as it can cause network cycles to break and also ligands/clusters to become disconnected from the network. Although it is possible to attempt to remove edges that 'do the least damage' (e.g. prioritising cycle edges), this would have to be done directly in the LOMAP API and could be done in later work. It's still a useful feature IMO as it allows users to run FEP on the most reliable sub-network(s) of the series.

For all cases the network is still plotted correctly, although in 3) there can of course be disconnected parts of the network drawn. In 3), completely disconnected nodes are excluded from the network drawing.

