### PR TITLE
SOMD analysis without subsampling

### DIFF
--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -531,6 +531,13 @@ class Relative():
         if proc.returncode != 0:
             raise _AnalysisError("SOMD free-energy analysis failed!")
 
+        #rerun without subsampling if the subsampling has resulted in less than 50 samples
+        with open("%s/mbar.txt" % work_dir) as file:
+            for line in file:
+                if "#WARNING SUBSAMPLING ENERGIES RESULTED IN LESS THAN 50 SAMPLES" in line:
+                    command = "%s mbar -i %s/lambda_*/simfile.dat -o %s/mbar.txt --overlap" % (_analyse_freenrg, work_dir, work_dir)
+                    proc = _subprocess.run(command, shell=True, stdout=_subprocess.PIPE, stderr=_subprocess.PIPE)
+        
         # Initialise list to hold the data.
         data = []
 

--- a/python/BioSimSpace/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/FreeEnergy/_relative.py
@@ -535,8 +535,12 @@ class Relative():
         with open("%s/mbar.txt" % work_dir) as file:
             for line in file:
                 if "#WARNING SUBSAMPLING ENERGIES RESULTED IN LESS THAN 50 SAMPLES" in line:
+                    print("Subsampling resulted in less than 50 samples, is being turned off for %s" % (work_dir))
                     command = "%s mbar -i %s/lambda_*/simfile.dat -o %s/mbar.txt --overlap" % (_analyse_freenrg, work_dir, work_dir)
                     proc = _subprocess.run(command, shell=True, stdout=_subprocess.PIPE, stderr=_subprocess.PIPE)
+                    if proc.returncode != 0:
+                        raise _AnalysisError("SOMD free-energy analysis failed!")
+                    break
         
         # Initialise list to hold the data.
         data = []


### PR DESCRIPTION
Concerning a transformation in SOMD (ejm31 to ejm42 tyk2 - https://github.com/michellab/BioSimSpace/pull/244#issuecomment-985444208 ) the analysis resulted in a large error because subsampling resulted in less than 50 samples for the bound leg.
When this transformation was rerun, the free energy analysis subsampling still resulted in less than 50 samples for the bound leg and even more vastly wrong results. With the subsampling turned off then for that leg, the results are much better (the experimental is -0.24 kcal/mol)


  | result (kcal/mol) | error
-- | -- | --
subsampling on and resulting in less than 50 samples | -14.7274 | 1.2025
subsampling off if less than 50 samples for that leg | -0.201 | 0.0727

So I think this code change may be a way to avoid that automatically without manually needing to check the output files?