### PR TITLE
Allow BSS to do ligand in water decoupling calculations

### DIFF
--- a/.github/workflows/Sandpit_exs.yml
+++ b/.github/workflows/Sandpit_exs.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install -c conda-forge -c michellab/label/dev biosimspace python=3.7 --only-deps
-          mamba install -c conda-forge ambertools
+          mamba install -c conda-forge ambertools alchemlyb
           mamba install -c bioconda gromacs
 
       - name: Install the dev version

--- a/.github/workflows/Sandpit_exs.yml
+++ b/.github/workflows/Sandpit_exs.yml
@@ -1,0 +1,49 @@
+name: Sandpit_exs_CI
+
+on:
+  # run once a day at noon UTC
+  schedule:
+    - cron: "0 12 * * *"
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["ubuntu-latest", "macOS-latest",]
+        python-version: ["3.7", ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: bss_build
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
+
+      - name: Install dependency
+        shell: bash -l {0}
+        run: |
+          mamba install -c conda-forge -c michellab/label/dev biosimspace python=3.7 --only-deps
+          mamba install -c conda-forge ambertools
+          mamba install -c bioconda gromacs
+
+      - name: Install the dev version
+        shell: bash -l {0}
+        run: |
+          cd python
+          python setup.py develop
+          cd ..
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          pytest -v --color=yes test/Sandpit/Exscientia/

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_decouple.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_decouple.py
@@ -1,0 +1,95 @@
+import warnings
+
+from Sire import Base as _SireBase
+
+from .._SireWrappers import Molecule as _Molecule
+from .._Exceptions import IncompatibleError as _IncompatibleError
+
+
+def decouple(molecule, property_map0=None, property_map1=None, intramol=True):
+    """Make the molecule as being decoupled, where the interactions with the
+    rest of the environment are removed, or annihilate, where the interactions
+    within the molecule are removed as well (choose this mode with
+    intramol=False).
+
+        Parameters
+        ----------
+
+        molecule : BioSimSpace._SireWrappers.Molecule
+            The molecule to be decoupled or annihilated.
+
+        property_map0 : dict
+            A dictionary that maps "properties" in this molecule to their
+            user defined values at the start of the transformation. This allows
+            user to selectively turn on or off the charge or the vdw
+            interactions e.g. { "charge" : True, "LJ" : True}
+
+        property_map1 : dict
+            A dictionary that maps "properties" in this molecule to their
+            user defined values at the end of the transformation. This allows
+            user to selectively turn on or off the charge or the vdw
+            interactions e.g. { "charge" : False, "LJ" : False}
+
+        intramol : bool
+            Whether to remove the intra-molecule forces, thereby annihilate the
+            molecule instead of decouple it.
+
+        Returns
+        -------
+
+        decoupled : Sire.Mol.Molecule
+            The molecule marked as being decoupled.
+    """
+    # Validate input.
+
+    if not isinstance(molecule, _Molecule):
+        raise TypeError("'molecule' must be of type 'BioSimSpace._SireWrappers.Molecule'")
+
+    # Cannot decouple a perturbable molecule.
+    if molecule.isDecoupled():
+        raise _IncompatibleError("'molecule' has already been decoupled!")
+
+    if property_map0 is None and property_map1 is None:
+        property_map0 = {"charge": True, "LJ": True}
+        property_map1 = {"charge": False, "LJ": False}
+    if property_map0 is None:
+        property_map0 = {}
+    if property_map1 is None:
+        property_map1 = {}
+
+    # Check the keys in the property_map
+    for property_map in (property_map0, property_map1):
+        if not isinstance(property_map, dict):
+            raise TypeError("'property_map' must be of type 'dict'")
+        for key in property_map:
+            if not key in ('charge', 'LJ'):
+                warnings.warn(f'Key {key} not supported for decouple, will be '
+                              f'ignored. The recognised keys are '
+                              f'("charge", "LJ")')
+
+    if not isinstance(intramol, bool):
+        raise TypeError("'intramol' must be of type 'bool'")
+
+    # Create a copy of this molecule.
+    mol = _Molecule(molecule)
+    mol_sire = mol._sire_object
+
+    # Edit the molecule
+    mol_edit = mol_sire.edit()
+
+    # Set the start and the end state
+    mol_edit.setProperty("charge0", _SireBase.wrap(property_map0.get("charge",True)))
+    mol_edit.setProperty("charge1", _SireBase.wrap(property_map1.get("charge", True)))
+    mol_edit.setProperty("LJ0", _SireBase.wrap(property_map0.get("LJ", True)))
+    mol_edit.setProperty("LJ1", _SireBase.wrap(property_map1.get("LJ", True)))
+
+    mol_edit.setProperty("annihilated", _SireBase.wrap(not intramol))
+
+    # Flag that this molecule is decoupled.
+    mol_edit.setProperty("is_decoupled", _SireBase.wrap(True))
+
+    # Update the Sire molecule object of the new molecule.
+    mol._sire_object = mol_edit.commit()
+
+    return mol
+

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
@@ -216,7 +216,7 @@ class Relative():
                     raise _MissingSoftwareError("Cannot use GROMACS engine as GROMACS is not installed!")
 
                 # The system must have a perturbable molecule.
-                if system.nPerturbableMolecules() == 0:
+                if system.nPerturbableMolecules() == 0 and system.nDecoupledMolecules() == 0:
                     raise ValueError("The system must contain a perturbable molecule! "
                                      "Use the 'BioSimSpace.Align' package to map and merge molecules.")
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -178,7 +178,8 @@ class Gromacs(_process.Process):
 
         if isinstance(self._protocol, _Protocol._FreeEnergyMixin):
             # Check that the system contains a perturbable molecule.
-            if self._system.nPerturbableMolecules() == 0:
+            if self._system.nPerturbableMolecules() == 0 \
+                    and system.nDecoupledMolecules() == 0:
                 raise ValueError("'BioSimSpace.Protocol.FreeEnergy' requires a "
                                  "perturbable molecule!")
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -779,7 +779,7 @@ class Gromacs(_process.Process):
 
         # Warnings don't trigger an error. Set to a suitably large number.
         if self._ignore_warnings:
-            command += " --maxwarn 1000"
+            command += " --maxwarn -1"
 
         # Run the command.
         proc = _subprocess.run(_shlex.split(command), shell=False, text=True,

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -407,7 +407,7 @@ class ConfigFactory:
         protocol_dict = {
             "nstlog": self._report_interval,                                        # Interval between writing to the log file.
             "nstenergy": self._restart_interval,                                    # Interval between writing to the energy file.
-            "nstxout": self._restart_interval,                                      # Interval between writing to the trajectory file.
+            "nstxout-compressed": self._restart_interval,                                      # Interval between writing to the trajectory file.
         }
 
         # Minimisation.
@@ -420,10 +420,7 @@ class ConfigFactory:
 
         # Constraints.
         if not isinstance(self.protocol, _Protocol.Minimisation):
-            if timestep >= 0.004:
-                protocol_dict["constraints"] = "all-bonds"                          # If HMR, all constraints
-            else:
-                protocol_dict["constraints"] = "h-bonds"                            # Rigid bonded hydrogens.
+            protocol_dict["constraints"] = "h-bonds"                            # Rigid bonded hydrogens.
             protocol_dict["constraint-algorithm"] = "LINCS"                         # Linear constraint solver.
 
         # PBC.
@@ -450,17 +447,14 @@ class ConfigFactory:
 
         # Restraints.
         if isinstance(self.protocol, _Protocol.Equilibration):
-            protocol_dict["refcoord-scaling"] = "all"                               # The actual restraints need to be defined elsewhere.
+            protocol_dict["refcoord-scaling"] = "com"                               # The actual restraints need to be defined elsewhere.
 
         # Pressure control.
         if not isinstance(self.protocol, _Protocol.Minimisation):
             if self.protocol.getPressure() is not None:
                 # Don't use barostat for vacuum simulations.
                 if self._has_box and self._has_water:
-                    if isinstance(self.protocol, _Protocol.Equilibration):
-                        protocol_dict["pcoupl"] = "c-rescale"                       # Barostat type.
-                    else:
-                        protocol_dict["pcoupl"] = "parrinello-rahman"               # Barostat type.
+                    protocol_dict["pcoupl"] = "c-rescale"                       # Barostat type.
                     protocol_dict["tau-p"] = 1                                      # 1ps time constant for pressure coupling.
                     protocol_dict["ref-p"] = f"{self.protocol.getPressure().bar().value():.5f}"  # Pressure in bar.
                     protocol_dict["compressibility"] = "4.5e-5"                     # Compressibility of water.
@@ -469,7 +463,8 @@ class ConfigFactory:
 
         # Temperature control.
         if not isinstance(self.protocol, _Protocol.Minimisation):
-            protocol_dict["integrator"] = "sd"                                      # Langevin dynamics.
+            protocol_dict["integrator"] = "md"                                      # leap-frog dynamics.
+            protocol_dict["tcoupl"] = "v-rescale"
             protocol_dict["tc-grps"] = "system"                                     # A single temperature group for the entire system.
             protocol_dict["tau-t"] = 2                                              # Collision frequency (ps).
 
@@ -500,10 +495,13 @@ class ConfigFactory:
         if isinstance(self.protocol, _Protocol._FreeEnergyMixin):
             protocol_dict["free-energy"] = "yes"                                    # Free energy mode.
             protocol_dict["calc-lambda-neighbors"] = -1                             # Calculate MBAR energies.
-            protocol = [str(x) for x in self.protocol.getLambdaValues()]
-            protocol_dict["fep-lambdas"] = " ".join(protocol)                       # Lambda values.
-            idx = self._protocol.getLambdaIndex()
-            protocol_dict["init-lambda-state"] = idx                                # Current lambda value.
+            LambdaValues = self.protocol.getLambdaValues(type='dataframe')
+            for name in ['fep', 'bonded', 'coul', 'vdw', 'restraint', 'mass',
+                           'temperature']:
+                if name in LambdaValues:
+                    protocol_dict["{}-lambdas".format(name)] = \
+                        ' '.join(list(map(str, LambdaValues[name].to_list())))
+            protocol_dict["init-lambda-state"] = self.protocol.getLambdaIndex()     # Current lambda value.
             protocol_dict["nstcalcenergy"] = 200                                    # Calculate energies every 200 steps.
             protocol_dict["nstdhdl"] = 200                                          # Write gradients every 200 steps.
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_mixin.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_free_energy_mixin.py
@@ -1,5 +1,10 @@
 __all__ = ["_FreeEnergyMixin"]
 
+import warnings
+
+import numpy as np
+import pandas as pd
+
 from ._protocol import Protocol as _Protocol
 
 class _FreeEnergyMixin(_Protocol):
@@ -18,16 +23,16 @@ class _FreeEnergyMixin(_Protocol):
            Parameters
            ----------
 
-           lam : float
+           lam : float or pandas.Series
                The perturbation parameter: [0.0, 1.0]
 
-           lam_vals : [float]
-               The list of lambda parameters.
+           lam_vals : [float] or pandas.DataFrame
+               A list of lambda values.
 
-           min_lam : float
+           min_lam : float or pandas.Series
                The minimum lambda value.
 
-           max_lam : float
+           max_lam : float or pandas.Series
                The maximum lambda value.
 
            num_lam : int
@@ -60,16 +65,16 @@ class _FreeEnergyMixin(_Protocol):
         if self._is_customised:
             return "<BioSimSpace.Protocol.Custom>"
         else:
-            return ("<BioSimSpace.Protocol._FreeEnergyMixin: lam=%5.4f, lam_vals=%r>"
-                   ) % (self._lambda, self._lambda_vals)
+            return ("<BioSimSpace.Protocol._FreeEnergyMixin: lam=\n%s, lam_vals=\n%s>"
+                   ) % (self._lambda.to_string(), self._lambda_vals.to_string())
 
     def __repr__(self):
         """Return a string showing how to instantiate the object."""
         if self._is_customised:
             return "<BioSimSpace.Protocol.Custom>"
         else:
-            return ("<BioSimSpace.Protocol._FreeEnergyMixin: lam=%5.4f, lam_vals=%r>"
-                    ) % (self._lambda, self._lambda_vals)
+            return ("<BioSimSpace.Protocol._FreeEnergyMixin: lam=\n%s, lam_vals=\n%s>"
+                    ) % (self._lambda.to_string(), self._lambda_vals.to_string())
 
     def getPerturbationType(self):
         """Get the perturbation type.
@@ -115,38 +120,91 @@ class _FreeEnergyMixin(_Protocol):
 
         self._perturbation_type = perturbation_type
 
-    def getLambda(self):
+    @staticmethod
+    def _check_column_name(df):
+        '''Check if the dataframe or series has the right column name.'''
+        permitted_names = ['fep', 'bonded', 'coul', 'vdw', 'restraint', 'mass',
+                           'temperature']
+        if isinstance(df, pd.Series):
+            for name in df.index:
+                if not name in permitted_names:
+                    warnings.warn(f'{name} not in the list of permitted names, '
+                                  f'so may not be supported by the MD Engine '
+                                  f'({" ".join(permitted_names)}).')
+        elif isinstance(df, pd.DataFrame):
+            for name in df.columns:
+                if not name in permitted_names:
+                    warnings.warn(f'{name} not in the list of permitted names, '
+                                  f'so may not be supported by the MD Engine '
+                                  f'({" ".join(permitted_names)}).')
+
+    def getLambda(self, type='float'):
         """Get the value of the perturbation parameter.
+
+           Parameters
+           ----------
+
+           type : string
+               The type of lambda to be returned. ('float', 'series')
 
            Returns
            -------
 
-           lam : float
+           lam : float or pd.Series
                The value of the perturbation parameter.
         """
-        return self._lambda
+        if type.lower() == 'float':
+            if len(self._lambda) == 1:
+                return float(self._lambda)
+            else:
+                warnings.warn(
+                    f'The {self._lambda} has more than one value, return as pd.Series.')
+                return self._lambda
+        elif type.lower() == 'series':
+            return self._lambda
+        else:
+            raise ValueError(f"{type} could only be 'float' or 'series'.")
 
     def getLambdaIndex(self):
-        """Get the index of the lambda value within the lambda array.
+        '''Get the index of the lambda value within the lambda array.
 
            Returns
            -------
 
            index : int
                The index of the lambda value in teh lambda array.
-        """
-        return self._lambda_vals.index(self._lambda)
+        '''
+        return self._lambda_vals.index[(self._lambda_vals==self._lambda).all(axis=1)].tolist()[0]
 
-    def getLambdaValues(self):
-        """Get the list of lambda values.
+    def getLambdaValues(self, type='list'):
+        """Get the lambda values.
+
+           Parameters
+           ----------
+
+           type : string
+               The type of lambda values to be returned. ('list', 'dataframe')
 
            Returns
            -------
 
-           lam_vals : [float]
-               The list of lambda values.
+           lam_vals : [float, ] or pd.DataFrame
+               The lambda values.
         """
-        return self._lambda_vals
+        if type.lower() == 'list':
+            lambda_list = self._lambda_vals.values.tolist()
+            if len(lambda_list[0]) == 1:
+                # Ensure that return [float, ] when lambda_list only has one
+                # column
+                return [lam[0] for lam in lambda_list]
+            else:
+                warnings.warn(
+                    f'The {self._lambda_vals} has more than one column, return as pd.DataFrame.')
+                return self._lambda_vals
+        elif type.lower() == 'dataframe':
+            return self._lambda_vals
+        else:
+            raise ValueError(f"{type} could only be 'list' or 'dataframe'.")
 
     def setLambdaValues(self, lam, lam_vals=None, min_lam=None, max_lam=None, num_lam=None):
         """Set the list of lambda values.
@@ -154,62 +212,57 @@ class _FreeEnergyMixin(_Protocol):
            Parameters
            ----------
 
-           lam : float
+           lam : float or pandas.Series
                The perturbation parameter: [0.0, 1.0]
 
-           lam_vals : [float]
+           lam_vals : [float] or pandas.DataFrame
                A list of lambda values.
 
-           min_lam : float
+           min_lam : float or pandas.Series
                The minimum lambda value.
 
-           max_lam : float
+           max_lam : float or pandas.Series
                The maximum lambda value.
 
            num_lam : int
                The number of lambda values.
         """
-
-        # Convert int to float.
-        if type(lam) is int:
-            lam = float(lam)
-
-        # Validate the lambda parameter.
-        if type(lam) is not float:
-            raise TypeError("'lam' must be of type 'float'.")
+        if not isinstance(lam, pd.Series):
+            # For pandas < 1.4, TypeError won't be raised if the type cannot
+            # be converted to float
+            lam = pd.Series(data={'fep': lam}, dtype=float)
+        else:
+            self._check_column_name(lam)
 
         self._lambda = lam
 
         # A list of lambda values takes precedence.
         if lam_vals is not None:
-            # Convert tuple to list.
-            if type(lam_vals) is tuple:
-                lam_vals = list(lam_vals)
-
-            # Make sure list (or tuple) has been passed.
-            if type(lam_vals) is not list:
-                raise TypeError("'lam_vals' must be of type 'list'.")
-
-            # Make sure all lambda values are of type 'float'.
-            if not all(isinstance(x, float) for x in lam_vals):
-                raise TypeError("'lam_vals' must contain values of type 'float'.")
+            if not isinstance(lam_vals, pd.DataFrame):
+                # For pandas < 1.4, TypeError won't be raised if the type
+                # cannot be converted to float
+                lam_vals = pd.DataFrame(data={'fep': lam_vals},
+                                            dtype=float)
+            else:
+                self._check_column_name(lam_vals)
 
             # Make sure all values are in range [0.0, 1.0]
-            for lam in lam_vals:
-                if lam < 0:
-                    raise ValueError("'lam_vals' must contain values in range [0.0, 1.0]")
-                elif lam > 1:
-                    raise ValueError("'lam_vals' must contain values in range [0.0, 1.0]")
+            if not ((lam_vals <= 1).all(axis=None) and (lam_vals >= 0).all(axis=None)):
+                raise ValueError(
+                    "'lam_vals' must contain values in range [0.0, 1.0]")
 
             # Sort the values.
-            lam_vals.sort()
+            lam_vals.sort_values(lam_vals.columns.values.tolist(), inplace=True)
 
             # Make sure there are no duplicates.
-            if len(set(lam_vals)) < len(lam_vals):
+            if lam_vals.duplicated().any():
                 raise ValueError("'lam_vals' cannot contain duplicate values!")
 
+            # Update the index to the sorted rows
+            lam_vals.reset_index(drop=True, inplace=True)
+
             # Make sure the lambda value is in the list.
-            if not lam in lam_vals:
+            if not (lam==lam_vals).all(axis=1).any():
                 raise ValueError("'lam' is not a member of the 'lam_vals' list!")
 
             # Set the values.
@@ -217,47 +270,49 @@ class _FreeEnergyMixin(_Protocol):
 
         else:
             # Convert int to float.
+            if not isinstance(min_lam, pd.Series):
+                # For pandas < 1.4, TypeError won't be raised if the type cannot
+                # be converted to float
+                min_lam = pd.Series(data={'fep': min_lam}, dtype=float)
+            else:
+                self._check_column_name(lam_vals)
 
-            if type(min_lam) is int:
-                min_lam = float(min_lam)
+            if not isinstance(max_lam, pd.Series):
+                # For pandas < 1.4, TypeError won't be raised if the type cannot
+                # be converted to float
+                max_lam = pd.Series(data={'fep': max_lam}, dtype=float)
+            else:
+                self._check_column_name(lam_vals)
 
-            if type(max_lam) is int:
-                max_lam = float(max_lam)
-
-            # Validate type.
-
-            if type(min_lam) is not float:
-                raise TypeError("'min_lam' must be of type 'float'.")
-
-            if type(max_lam) is not float:
-                raise TypeError("'max_lam' must be of type 'float'.")
-
-            if type(num_lam) is not int:
+            if not type(num_lam) is int:
                 raise TypeError("'num_lam' must be of type 'int'.")
 
             # Validate values.
-
-            if min_lam < 0 or min_lam > 1:
+            if (min_lam < 0).any() or (min_lam > 1).any():
                 raise ValueError("'min_lam' must be in range [0.0, 1.0]")
 
-            if max_lam < 0 or max_lam > 1:
+            if (max_lam < 0).any() or (max_lam > 1).any():
                 raise ValueError("'max_lam' must be in range [0.0, 1.0]")
 
             if num_lam <=2:
                 raise ValueError("'num_lam' must be greater than 2!")
 
-            if min_lam >= max_lam:
+            if not (min_lam.index == max_lam.index).all():
+                raise ValueError("'min_lam' and 'max_lam' must have the same index!")
+
+            if (min_lam >= max_lam).any():
                 raise ValueError("'min_lam' must be less than 'max_lam'!")
 
             # Set values.
+            lambda_vals = pd.DataFrame(
+                data=np.linspace(min_lam, max_lam, num_lam),
+                columns=min_lam.index)
 
-            self._lambda_vals = []
-            step = (max_lam - min_lam) / (num_lam - 1)
-
-            for x in range(0, num_lam):
-                self._lambda_vals.append(round(min_lam + (x * step), 5))
+            self._lambda_vals = lambda_vals.round(5)
 
             # Make sure the lambda value is in the list.
-            if not self._lambda in self._lambda_vals:
-                raise ValueError("'lam' (%5.4f) is not a member of the 'lam_vals' list: %s" \
-                    % (self._lambda, self._lambda_vals))
+            if not (self._lambda==self._lambda_vals).all(axis=1).any():
+                raise ValueError("'lam' \n%s \n is not a member of the 'lam_vals': \n%s" \
+                    % (self._lambda.to_string(), self._lambda_vals.to_string()))
+
+

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -449,6 +449,21 @@ class Molecule(_SireWrapper):
         """
         return self._is_perturbable
 
+    def isDecoupled(self):
+        """Whether this molecule is decoupled, i.e. it can be used in a
+           free-energy decoupling simulation.
+
+           Returns
+           -------
+
+           is_decoupled : bool
+               Whether the molecule is decoupled.
+        """
+        if self._sire_object.hasProperty('is_decoupled'):
+            return self._sire_object.property('is_decoupled').value()
+        else:
+            return False
+
     def isWater(self, property_map={}):
         """Whether this is a water molecule.
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -729,6 +729,34 @@ class System(_SireWrapper):
         """
         return len(self.getPerturbableMolecules())
 
+    def getDecoupledMolecules(self):
+        """Return a list containing all of the decoupled molecules in the system.
+
+           Returns
+           -------
+
+           molecules : [:class:`Molecule <BioSimSpace._SireWrappers.Molecule>`]
+               A list of decoupled molecules.
+        """
+
+        molecules = []
+
+        for mol in self:
+            if mol.isDecoupled():
+                molecules.append(_Molecule(mol))
+        return molecules
+
+    def nDecoupledMolecules(self):
+        """Return the number of decoupled molecules in the system.
+
+           Returns
+           -------
+
+           num_decoupled : int
+               The number of decoupled molecules in the system.
+        """
+        return len(self.getDecoupledMolecules())
+
     def repartitionHydrogenMass(self, factor=4, water="no", property_map={}):
         """Redistrubute mass of heavy atoms connected to bonded hydrogens into
            the hydrogen atoms. This allows the use of larger simulation

--- a/test/Sandpit/Exscientia/Align/test_decouple.py
+++ b/test/Sandpit/Exscientia/Align/test_decouple.py
@@ -1,0 +1,65 @@
+import pytest
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+from BioSimSpace.Sandpit.Exscientia.Align._decouple import decouple
+
+
+@pytest.fixture()
+def mol():
+    # Benzene.
+    mol = BSS.Parameters.openff_unconstrained_2_0_0(
+        "c1ccccc1").getMolecule()
+    return mol
+
+def test_sanity(mol):
+    assert mol.isDecoupled() == False
+
+@pytest.mark.parametrize("charge0", [True, False])
+@pytest.mark.parametrize("charge1", [True, False])
+@pytest.mark.parametrize("LJ0", [True, False])
+@pytest.mark.parametrize("LJ1", [True, False])
+def test_set_property_map(mol, charge0, charge1, LJ0, LJ1):
+    '''Test if the charge and LJ are set properly'''
+    property_map0 = {"charge": charge0, "LJ": LJ0}
+    property_map1 = {"charge": charge1, "LJ": LJ1}
+    new = decouple(mol, property_map0=property_map0,
+                    property_map1=property_map1)
+    assert new._sire_object.property('charge0').value() == charge0
+    assert new._sire_object.property('charge1').value() == charge1
+    assert new._sire_object.property('LJ0').value() == LJ0
+    assert new._sire_object.property('LJ1').value() == LJ1
+    assert new.isDecoupled() == True
+    assert new._sire_object.property('annihilated').value() == False
+
+def test_ommit_property_map(mol):
+    '''Test if the charge and LJ are set to True by default'''
+    new = decouple(mol)
+    assert new._sire_object.property('charge0').value() == True
+    assert new._sire_object.property('charge1').value() == False
+    assert new._sire_object.property('LJ0').value() == True
+    assert new._sire_object.property('LJ1').value() == False
+    assert new.isDecoupled() == True
+    assert new._sire_object.property('annihilated').value() == False
+
+def test_intramol(mol):
+    '''Test the case of intramol=False'''
+    new = decouple(mol, intramol=False, property_map0={}, property_map1={})
+    assert new.isDecoupled() == True
+    assert new._sire_object.property('annihilated').value() == True
+
+def test_getDecoupledMolecules(mol):
+    '''Test the method of DecoupledMolecules'''
+    new = decouple(mol)
+    decoupled_mol_list = new.toSystem().getDecoupledMolecules()
+    assert isinstance(decoupled_mol_list[0], BSS._SireWrappers.Molecule)
+    assert new.toSystem().nDecoupledMolecules() == 1
+
+def test_no_DecoupledMolecules(mol):
+    '''Test the method of DecoupledMolecules when there is no decoupled mols.'''
+    assert mol.toSystem().nDecoupledMolecules() == 0
+
+def test_topology(mol, tmp_path):
+    '''Test if the decoupled file could be written correctly.'''
+    new = decouple(mol)
+    BSS.IO.saveMolecules(str(tmp_path / 'topol'), new.toSystem(), 'grotop')
+    assert (tmp_path / 'topol.top').is_file()

--- a/test/Sandpit/Exscientia/Free_Energy/test_relative.py
+++ b/test/Sandpit/Exscientia/Free_Energy/test_relative.py
@@ -1,0 +1,59 @@
+import pathlib
+
+import pytest
+import pandas as pd
+import numpy as np
+from alchemlyb.parsing.gmx import extract_u_nk
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+from BioSimSpace.Sandpit.Exscientia.Protocol import FreeEnergyEquilibration
+from BioSimSpace.Sandpit.Exscientia.Align._decouple import decouple
+from BioSimSpace.Sandpit.Exscientia import Types as _Types
+
+class Test_gmx_ABFE():
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def freenrg():
+        m = BSS.Parameters.openff_unconstrained_2_0_0("c1ccccc1").getMolecule()
+        decouple_m = decouple(m,
+                              property_map0={"charge": True, "LJ": True},
+                              property_map1={"charge": False, "LJ": False},
+                              intramol=False)
+        solvated = BSS.Solvent.tip3p(molecule=decouple_m,
+                                     box=3 * [3 * BSS.Units.Length.nanometer])
+        protocol = FreeEnergyEquilibration(
+            lam=pd.Series(data={'coul': 0.5, 'vdw': 0.0}),
+            lam_vals=pd.DataFrame(
+                data={'coul': [0.0, 0.5, 1.0, 1.0, 1.0],
+                      'vdw':  [0.0, 0.0, 0.0, 0.5, 1.0]}),
+            runtime=_Types.Time(0, "nanoseconds"),)
+        freenrg = BSS.FreeEnergy.Relative(solvated, protocol,
+                                          engine='GROMACS', )
+        freenrg.run()
+        freenrg.wait()
+        return freenrg
+
+    def test_file_exist(self, freenrg):
+        '''Test if all the files are there.'''
+        path = pathlib.Path(freenrg._work_dir)
+        for i in range(5):
+            assert (path / f'lambda_{i}' / 'gromacs.xvg').is_file()
+
+    def test_lambda(self, freenrg):
+        '''Test if the xvg files contain the correct lambda.'''
+        path = pathlib.Path(freenrg._work_dir)
+        for i, (coul, vdw) in enumerate(zip([0.0, 0.5, 1.0, 1.0, 1.0],
+                                            [0.0, 0.0, 0.0, 0.5, 1.0])):
+            u_nk = extract_u_nk(path / f'lambda_{i}' / 'gromacs.xvg', 300)
+            assert u_nk.index.names == ['time', 'coul-lambda', 'vdw-lambda']
+            assert np.isclose(u_nk.index.values[0][1], coul)
+            assert np.isclose(u_nk.index.values[0][2], vdw)
+
+    def test_lambda_value(self, freenrg):
+        '''Test if the xvg files contain the correct value.'''
+        path = pathlib.Path(freenrg._work_dir)
+        u_nk = extract_u_nk(path / 'lambda_0' / 'gromacs.xvg', 300)
+        assert np.isclose(u_nk.to_numpy(),
+                          [0., 2.87115501, 5.74231018, -1099.93073758,
+                           -2205.60375848],
+                          rtol=0.1).all()

--- a/test/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/test/Sandpit/Exscientia/Process/test_gromacs.py
@@ -52,7 +52,7 @@ def test_cool(system):
                                           temperature_end=BSS.Types.Temperature(0, "kelvin"))
 
     # Run the process and check that it finishes without error.
-    assert run_process(system, protocol)
+    assert run_process(system, protocol, extra_options={'verlet-buffer-tolerance': '2e-07'})
 
 @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
 def test_production(system):
@@ -64,11 +64,12 @@ def test_production(system):
     # Run the process and check that it finishes without error.
     assert run_process(system, protocol)
 
-def run_process(system, protocol):
+def run_process(system, protocol, extra_options=None):
     """Helper function to run various simulation protocols."""
 
     # Initialise the GROMACS process.
-    process = BSS.Process.Gromacs(system, protocol, name="test")
+    process = BSS.Process.Gromacs(system, protocol, name="test",
+                                  extra_options=extra_options)
 
     # Only run on a single MPI rank.
     process.setArg("-ntmpi", 1)

--- a/test/Sandpit/Exscientia/Protocol/test_config.py
+++ b/test/Sandpit/Exscientia/Protocol/test_config.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import pytest
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+from BioSimSpace.Sandpit.Exscientia.Protocol import FreeEnergyMinimisation
+
+class TestGromacs():
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def system():
+        # Benzene.
+        m0 = BSS.Parameters.openff_unconstrained_2_0_0(
+            "c1ccccc1").getMolecule()
+        # Toluene.
+        m1 = BSS.Parameters.openff_unconstrained_2_0_0(
+            "Cc1ccccc1").getMolecule()
+        atom_mapping = BSS.Align.matchAtoms(m0, m1)
+        m0 = BSS.Align.rmsdAlign(m0, m1, atom_mapping)
+        merged = BSS.Align.merge(m0, m1)
+        return merged.toSystem()
+
+    def test_fep(self, system):
+        '''Test if the default config writer will write the expected thing'''
+        protocol = FreeEnergyMinimisation(lam=0.0,
+                 lam_vals=None,
+                 min_lam=0.0,
+                 max_lam=1.0,
+                 num_lam=11,
+                 steps=10000,
+                 perturbation_type="full")
+        freenrg = BSS.FreeEnergy.Relative(system, protocol, engine='GROMACS', )
+        with open(f"{freenrg._work_dir}/lambda_6/gromacs.mdp", 'r') as f:
+            mdp_text = f.read()
+            assert 'fep-lambdas = 0.0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0' in mdp_text
+            assert 'init-lambda-state = 6' in mdp_text
+
+    def test_fep_df(self, system):
+        '''Test if the default config writer configured with the pd.DataFrame
+        will write the expected thing.'''
+        protocol = FreeEnergyMinimisation(lam=pd.Series(data={'fep': 0.0}),
+                 lam_vals=None,
+                 min_lam=pd.Series(data={'fep': 0.0}),
+                 max_lam=pd.Series(data={'fep': 1.0}),
+                 num_lam=11,
+                 steps=10000,
+                 perturbation_type="full")
+        freenrg = BSS.FreeEnergy.Relative(system, protocol, engine='GROMACS', )
+        with open(f"{freenrg._work_dir}/lambda_6/gromacs.mdp", 'r') as f:
+            mdp_text = f.read()
+            assert 'fep-lambdas = 0.0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0' in mdp_text
+            assert 'init-lambda-state = 6' in mdp_text
+
+    def test_staged_fep_df(self, system):
+        '''Test if the multi-stage lambda will be written correctly'''
+        protocol = FreeEnergyMinimisation(
+            lam=pd.Series(data={'bonded': 0.0, 'coul': 0.0, 'vdw': 0.0}),
+            lam_vals=pd.DataFrame(
+                data={'bonded': [0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0],
+                      'coul': [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
+                      'vdw': [0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0]}),
+            steps=10000, perturbation_type="full")
+        freenrg = BSS.FreeEnergy.Relative(system, protocol, engine='GROMACS', )
+        with open(f"{freenrg._work_dir}/lambda_6/gromacs.mdp", 'r') as f:
+            mdp_text = f.read()
+            assert 'bonded-lambdas = 0.0 0.25 0.5 0.75 1.0 1.0 1.0' in mdp_text
+            assert 'coul-lambdas = 0.0 0.0 0.0 0.5 1.0 1.0 1.0' in mdp_text
+            assert 'vdw-lambdas = 0.0 0.0 0.0 0.0 0.0 0.5 1.0' in mdp_text
+            assert 'init-lambda-state = 6' in mdp_text

--- a/test/Sandpit/Exscientia/Protocol/test_free_energy_mixin.py
+++ b/test/Sandpit/Exscientia/Protocol/test_free_energy_mixin.py
@@ -1,0 +1,229 @@
+import pandas as pd
+import pytest
+import numpy as np
+
+from BioSimSpace.Sandpit.Exscientia.Protocol import _FreeEnergyMixin
+
+class Test_List_num_lam():
+    '''Test if the new _FreeEnergyMixin class could handle the num_lam as input
+    with input as float'''
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def protocol():
+        protocol = _FreeEnergyMixin(lam=0.5, lam_vals=None, min_lam=0.0,
+                                    max_lam=1.0, num_lam=11)
+        return protocol
+
+    def test_getLambdaValues(self, protocol):
+        value = protocol.getLambdaValues(type='list')
+        assert isinstance(value, list)
+        assert isinstance(value[5], float)
+        assert np.isclose(value[5], 0.5)
+
+    def test_getLambda(self, protocol):
+        value = protocol.getLambda(type='float')
+        assert isinstance(value, float)
+        assert np.isclose(value, 0.5)
+
+    def test_getLambdaIndex(self, protocol):
+        value = protocol.getLambdaIndex()
+        assert isinstance(value, int)
+        assert np.isclose(value, 5)
+
+    def test_getLambdaValues_df(self, protocol):
+        value = protocol.getLambdaValues(type='dataframe')
+        assert isinstance(value, pd.DataFrame)
+        assert isinstance(value.loc[5], pd.Series)
+        assert np.isclose(value.loc[5], 0.5)
+
+    def test_getLambda_Series(self, protocol):
+        value = protocol.getLambda(type='series')
+        assert isinstance(value, pd.Series)
+        assert np.isclose(value, 0.5)
+
+class Test_List_lam_vals(Test_List_num_lam):
+    '''Test if the new _FreeEnergyMixin class could handle the lam_vals as input
+    with input as float'''
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def protocol():
+        protocol = _FreeEnergyMixin(lam=0.5,
+                                    # Note that 0.5 is the first to check if being sorted
+                                    lam_vals=[0.5, 0.0, 0.1, 0.2, 0.3, 0.4,
+                                              0.6, 0.7, 0.8, 0.9, 1.0], )
+        return protocol
+
+class Test_df_lam_vals(Test_List_lam_vals):
+    '''Test if the new _FreeEnergyMixin class could handle the lam_vals as input
+    with input as pd.DataFrame'''
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def protocol():
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'fep': 0.5}),
+                                    # Note that 0.5 is the first to check if being sorted
+                                    lam_vals=pd.DataFrame(data={'fep':
+                                        [0.5, 0.0, 0.1, 0.2, 0.3, 0.4, 0.6,
+                                         0.7, 0.8, 0.9, 1.0]}))
+        return protocol
+
+class Test_df_num_lam(Test_List_num_lam):
+    '''Test if the new _FreeEnergyMixin class could handle the num_lam as input
+    with input as pd.DataFrame'''
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def protocol():
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'fep': 0.5}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'fep': 0.0}),
+                                    max_lam=pd.Series(data={'fep': 1.0}),
+                                    num_lam=11)
+        return protocol
+
+def test_df_num_lam():
+    '''Test using multiple column df as input to num_lam'''
+    protocol = _FreeEnergyMixin(lam=pd.Series(data={'bonded': 0.5,
+                                                    'coul': 0.5,
+                                                    'vdw': 0.5}),
+                                lam_vals=None,
+                                min_lam=pd.Series(data={'bonded': 0.0,
+                                                        'coul': 0.0,
+                                                        'vdw': 0.0}),
+                                max_lam=pd.Series(data={'bonded': 1.0,
+                                                        'coul': 1.0,
+                                                        'vdw': 1.0}),
+                                num_lam=11)
+    assert protocol.getLambdaIndex() == 5
+
+def test_df_num_lam_different_index():
+    '''Test the case where min_lam and max_lam don't have the same index.'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'bonded': 0.5}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'bonded': 0.0}),
+                                    max_lam=pd.Series(data={'coul': 1.0}),
+                                    num_lam=11)
+
+def test_larger_max_lam():
+    '''Test the case where max_lam larger than 1.'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'fep': 0.5}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'fep': 0.0}),
+                                    max_lam=pd.Series(data={'fep': 1.1}),
+                                    num_lam=11)
+
+def test_smaller_min_lam():
+    '''Test the case where min_lam smaller than 0.'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'fep': 0.5}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'fep': -0.1}),
+                                    max_lam=pd.Series(data={'fep': 1.0}),
+                                    num_lam=11)
+
+def test_smaller_num_lam():
+    '''Test the case where num_lam smaller than 2.'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'fep': 0.5}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'fep': 0.1}),
+                                    max_lam=pd.Series(data={'fep': 1.0}),
+                                    num_lam=1)
+
+def test_invert_min_max():
+    '''Test the case where min_lam is larger than max_lam.'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'fep': 0.5}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'fep': 1.0}),
+                                    max_lam=pd.Series(data={'fep': 0.0}),
+                                    num_lam=11)
+
+class Test_df_lam_vals():
+    '''Test the case where a 'real' multiple column lambda dataframe is given.'''
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def protocol():
+        protocol = _FreeEnergyMixin(
+            lam=pd.Series(data={'bonded': 0.75, 'coul': 0.5, 'vdw': 0.0}),
+            lam_vals=pd.DataFrame(
+                data={'bonded': [0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0],
+                      'coul': [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
+                      'vdw': [0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0]}))
+        return protocol
+
+    def test_getLambdaIndex(self, protocol):
+        assert protocol.getLambdaIndex() == 3
+
+    def test_getLambda(self, protocol):
+        '''check that a warning is given when the Lambda (with multiple fields)
+        cannot be converted to a float.'''
+        with pytest.warns(UserWarning):
+            Lambda = protocol.getLambda(type='float')
+            assert isinstance(Lambda, pd.Series)
+
+    def test_getLambdaValues(self, protocol):
+        '''check that a warning is given when the LambdaValues (with multiple
+        columns) cannot be converted to a list of float.'''
+        with pytest.warns(UserWarning):
+            Lambda = protocol.getLambdaValues(type='list')
+            assert isinstance(Lambda, pd.DataFrame)
+
+def test_not_in_num_lam():
+    '''Test The case where the lambda is not in lambda values generated by num_lam'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'bonded': 0.55,
+                                                        'coul': 0.55,
+                                                        'vdw': 0.55}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'bonded': 0.0,
+                                                            'coul': 0.0,
+                                                            'vdw': 0.0}),
+                                    max_lam=pd.Series(data={'bonded': 1.0,
+                                                            'coul': 1.0,
+                                                            'vdw': 1.0}),
+                                    num_lam=11)
+
+def test_num_lam_not_int():
+    '''Test The case where the num_lam is not int'''
+    with pytest.raises(TypeError):
+        protocol = _FreeEnergyMixin(lam=pd.Series(data={'bonded': 0.55,}),
+                                    lam_vals=None,
+                                    min_lam=pd.Series(data={'bonded': 0.0,}),
+                                    max_lam=pd.Series(data={'bonded': 1.0,}),
+                                    num_lam=0.1)
+
+def test_not_in_lam_vals():
+    '''Test The case where the lambda is not in lambda values'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(
+            lam=pd.Series(data={'bonded': 0.6, 'coul': 0.5, 'vdw': 0.0}),
+            lam_vals=pd.DataFrame(data={'bonded': [0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0],
+                                        'coul':   [0.0, 0.0,  0.0, 0.5,  1.0, 1.0, 1.0],
+                                        'vdw':    [0.0, 0.0,  0.0, 0.0,  0.0, 0.5, 1.0]}))
+
+def test_not_in_range():
+    '''Test The case where the lambda values is not in the range [0,1]'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(
+            lam=pd.Series(data={'bonded': 0.6, }),
+            lam_vals=pd.DataFrame(data={'bonded': [-0.1, 0.6],}))
+
+def test_duplicated():
+    '''Test The case where lambda values has duplication'''
+    with pytest.raises(ValueError):
+        protocol = _FreeEnergyMixin(
+            lam=pd.Series(data={'bonded': 0.75, 'coul': 0.5, 'vdw': 0.0}),
+            lam_vals=pd.DataFrame(data={'bonded': [0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0],
+                                        'coul':   [0.0, 0.0, 0.0,  0.0, 0.5,  1.0, 1.0, 1.0],
+                                        'vdw':    [0.0, 0.0, 0.0,  0.0, 0.0,  0.0, 0.5, 1.0]}))
+
+def test_nonvalid_index_name():
+    '''Test The case where lambda name aaa is not in the permitted list'''
+    with pytest.warns(UserWarning):
+        protocol = _FreeEnergyMixin(
+            lam=pd.Series(data={'aaa': 0.75, 'coul': 0.5, 'vdw': 0.0}),
+            lam_vals=pd.DataFrame(
+                data={'aaa': [0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0],
+                      'coul': [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
+                      'vdw': [0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 1.0]}))


### PR DESCRIPTION
Description
This PR adds allows one to decouple a molecule in solvent to compute the desolvation free energy.

Type of change
Bug fix (non-breaking change which fixes an issue)

- Fix the unit test to have them running fine on GMX 2022.1
- Change the maxwarn to use the Gromacs unlimited option

New feature (non-breaking change which adds functionality)

- Add the Github actions such that the CI will run all the unit tests
- Use pd.DataFrame and pd.Series internally in the BSS.Protocol._FreeEnergyMixin such that the more than one lambda state is supported.
- Add setLambda method to BSS.protocol.free_energy_mixin
- When supplying a Protocol with multiple lambda state, the BSS.Protocol._config could write multiple stage lambda into Gromacs mdp files 
- Change the default mdp options to better suit the gmx-2022
- Allow BSS.FreeEnergy.relative to use the new lambda config 
- Write test to ensure that the mdp file has been modified
- Allow the BSS.FreeEnergy.Relative to handle decoupled molecule
- Allow the BSS.Protocol.Config to edit the mdp file such that decoupled molecule could be written
- Add new method BSS.Align.Decouple to make molecule as being decoupled
- Allow BSS.mol and BSS.system to handle decoupled state properly

Changes (breaking change which adds functionality)

- Change the folder being created to use the index of the lambda (e.g. lambda_0, lambda_1 ... lambda_32)



