### PR TITLE
Copy __contains__ functionality into Exscientia sandpit.

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -163,6 +163,16 @@ class Molecule(_SireWrapper):
         else:
             return _Molecules(molecules)
 
+    def __contains__(self, other):
+        """Return whether other is in self."""
+
+        if not isinstance(other, (_Atom, _Residue)):
+            raise TypeError("'other' must be of type 'BioSimSpace._SireWrappers.Atom' "
+                            "or 'BioSimSpace._SireWrappers.Residue'.")
+
+        # Return whether the object comes from this molecule.
+        return self._sire_object.molecule() == other._sire_object.molecule()
+
     def copy(self):
         """Return a copy of this Molecule.
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_residue.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_residue.py
@@ -92,6 +92,15 @@ class Residue(_SireWrapper):
         return "<BioSimSpace.Residue: name=%r, molecule=%d, index=%d, nAtoms=%d>" \
             % (self.name(), self.moleculeNumber(), self.index(), self.nAtoms())
 
+    def __contains__(self, other):
+        """Return whether other is in self."""
+
+        if not isinstance(other, _Atom):
+            raise TypeError("'other' must be of type 'BioSimSpace._SireWrappers.Atom'.")
+
+        # Return whether the residue contains the atom.
+        return self._sire_object.contains(other._sire_object.atom().number())
+
     def __getitem__(self, key):
         """Get an atom from the residue."""
 

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -181,6 +181,16 @@ class System(_SireWrapper):
         # Return the new system.
         return system
 
+    def __contains__(self, other):
+        """Return whether other is in self."""
+
+        if not isinstance(other, (_Molecule, _Atom, _Residue)):
+            raise TypeError("'other' must be of type 'BioSimSpace._SireWrappers.Molecule' "
+                            "'BioSimSpace._SireWrappers.Atom', or 'BioSimSpace._SireWrappers.Residue'.")
+
+        # Return whether the object is in the system.
+        return self._sire_object.contains(other._sire_object.molecule())
+
     def __getitem__(self, key):
         """Get a molecule from the system."""
 

--- a/test/Sandpit/Exscientia/_SireWrappers/test_sire_wrappers.py
+++ b/test/Sandpit/Exscientia/_SireWrappers/test_sire_wrappers.py
@@ -2,21 +2,19 @@ import BioSimSpace.Sandpit.Exscientia as BSS
 
 import pytest
 
-# Glob the input files.
-files = BSS.IO.glob("test/input/amber/ala/*")
-
-# Load the molecular system.
-# This contains an alanin-dipeptide and 630 water molecules.
-system = BSS.IO.readMolecules(files)
+@pytest.fixture
+def system(scope="session"):
+    """Re-use the same molecuar system for each test."""
+    return BSS.IO.readMolecules("test/input/amber/ala/*")
 
 # Parameterise the function with a set of molecule indices.
 @pytest.mark.parametrize("index", [0, -1])
-def test_molecule_equivalence(index):
+def test_molecule_equivalence(system, index):
     # Make sure that we get the same molecule, however we extract it from
     # the system.
     assert system[index] == system.getMolecules()[index] == system.getMolecule(index)
 
-def test_iterators():
+def test_iterators(system):
     # Iterate over all molecules in the system, either directly,
     # or after calling getMolecules() and make sure they are equivalent.
 
@@ -42,7 +40,7 @@ def test_iterators():
         else:
             assert mol == system[idx] == molecules[idx] == system.getMolecule(idx)
 
-def test_atom_reindexing():
+def test_atom_reindexing(system):
     # Search for all oxygen atoms in water molecules water molecules within
     # the system.
     results = system.search("waters and element oxygen")
@@ -61,7 +59,7 @@ def test_atom_reindexing():
         # Increment the index. (3-point water.)
         index += 3
 
-def test_residue_reindexing():
+def test_residue_reindexing(system):
     # Search for all waters by residue name.
     results = system.search("resname WAT")
 
@@ -78,7 +76,7 @@ def test_residue_reindexing():
 
         index += 1
 
-def test_molecule_reindexing():
+def test_molecule_reindexing(system):
     # Search for all waters by residue name.
     results = system.search("resname WAT")
 
@@ -97,3 +95,36 @@ def test_molecule_reindexing():
         assert system.getIndex(residue.toMolecule()) == index
 
         index += 1
+
+def test_contains(system):
+    # Extract the first molecule.
+    m = system[0]
+
+    # Make sure the molecule is in the system.
+    assert m in system
+
+    # Make sure a copy of the molecule isn't in the system.
+    assert m.copy() not in system
+
+    # Extract the first residue of the molecule.
+    r = m.getResidues()[0]
+
+    # Extract the first atom of the residue.
+    a = r[0]
+
+    # Make sure the residue and atom are in the system.
+    assert r in system
+    assert a in system
+
+    # Make sure the residue and atom are in the molecule.
+    assert r in m
+    assert a in m
+
+    # Make sure that the atom is in the residue.
+    assert a in r
+
+    # Get an atom from a different residue.
+    a = system[1].getResidues()[0][0]
+
+    # Make sure the atom isn't in the residue.
+    assert a not in r


### PR DESCRIPTION
This PR adds `__contains__` operators to the wrapped Sire objects within the Exscientia sandpit. This allows the user to check whether objects contain other object, e.g.:

```python
# Check whether objects are in a system.
molecule in system
residue in system
atom in system

# Check whether objects are in a molecule.
residue in molecule
atom in molecule

# Check whether an atom is in a residue.
atom in residue
```