### PR TITLE
Fix value during dimensionless GeneralUnit conversion. [closes #332]

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Types/_general_unit.py
@@ -131,7 +131,7 @@ class GeneralUnit(_Type):
 
         # This is a dimensionless quantity, return the value as a float.
         if all(x == 0 for x in dimensions):
-            return float(value)
+            return general_unit.value()
 
         # Check to see if the dimensions correspond to a supported type.
         # If so, return an object of that type.

--- a/python/BioSimSpace/Types/_general_unit.py
+++ b/python/BioSimSpace/Types/_general_unit.py
@@ -131,7 +131,7 @@ class GeneralUnit(_Type):
 
         # This is a dimensionless quantity, return the value as a float.
         if all(x == 0 for x in dimensions):
-            return float(value)
+            return general_unit.value()
 
         # Check to see if the dimensions correspond to a supported type.
         # If so, return an object of that type.

--- a/test/Sandpit/Exscientia/Types/test_general_unit.py
+++ b/test/Sandpit/Exscientia/Types/test_general_unit.py
@@ -142,3 +142,13 @@ def test_dimensionless(string):
 
     # Check that we get back a float when divided by itself.
     assert isinstance(general_unit / general_unit, float)
+
+def test_dimensionless_value():
+    """Check that conversion to a dimensionless unit preserves the value
+       of the unit conversion.
+    """
+
+    value = (Units.Energy.kcal_per_mol / Units.Length.angstrom**2) / \
+            (Units.Energy.kj_per_mol / Units.Length.nanometer**2)
+
+    assert value == pytest.approx(418.4)

--- a/test/Types/test_general_unit.py
+++ b/test/Types/test_general_unit.py
@@ -142,3 +142,13 @@ def test_dimensionless(string):
 
     # Check that we get back a float when divided by itself.
     assert isinstance(general_unit / general_unit, float)
+
+def test_dimensionless_value():
+    """Check that conversion to a dimensionless unit preserves the value
+       of the unit conversion.
+    """
+
+    value = (Units.Energy.kcal_per_mol / Units.Length.angstrom**2) / \
+            (Units.Energy.kj_per_mol / Units.Length.nanometer**2)
+
+    assert value == pytest.approx(418.4)


### PR DESCRIPTION
This PR fixes the value when dimensionless `GeneralUnit` objects are converted to float. See #332.