### PR TITLE
Swap water topology before writing custom GRO file for vacuum simulations

### DIFF
--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -262,6 +262,9 @@ class Gromacs(_process.Process):
                 # Create a copy of the system.
                 system = self._system.copy()
 
+                # Convert the water model topology so that it matches the GROMACS naming convention.
+                system._set_water_topology("GROMACS")
+
                 # Create a 999.9 nm periodic box and apply to the system.
                 space = _SireVol.PeriodicBox(_SireMaths.Vector(9999, 9999, 9999))
                 system._sire_object.setProperty(self._property_map.get("space", "space"), space)

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -297,6 +297,9 @@ class Gromacs(_process.Process):
                 # Create a copy of the system.
                 system = self._system.copy()
 
+                # Convert the water model topology so that it matches the GROMACS naming convention.
+                system._set_water_topology("GROMACS")
+
                 # Create a 999.9 nm periodic box and apply to the system.
                 space = _SireVol.PeriodicBox(_SireMaths.Vector(9999, 9999, 9999))
                 system._sire_object.setProperty(self._property_map.get("space", "space"), space)

--- a/test/Process/test_gromacs.py
+++ b/test/Process/test_gromacs.py
@@ -64,6 +64,20 @@ def test_production(system):
     # Run the process and check that it finishes without error.
     assert run_process(system, protocol)
 
+@pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
+def test_vacuum_water(system):
+    """Regression test for ensuring the water topology is swapped for vacuum simulations."""
+
+    # Create a short production protocol.
+    protocol = BSS.Protocol.Minimisation(steps=100)
+
+    # Create a new system using the first two molecules of 'system'.
+    # This will be an alanine-dipeptide and water in vacuum.
+    new_system = (system[0] + system[1]).toSystem()
+
+    # Run the process and check that it finishes without error.
+    assert run_process(new_system, protocol)
+
 def run_process(system, protocol):
     """Helper function to run various simulation protocols."""
 

--- a/test/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/test/Sandpit/Exscientia/Process/test_gromacs.py
@@ -64,6 +64,20 @@ def test_production(system):
     # Run the process and check that it finishes without error.
     assert run_process(system, protocol)
 
+@pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
+def test_vacuum_water(system):
+    """Regression test for ensuring the water topology is swapped for vacuum simulations."""
+
+    # Create a short production protocol.
+    protocol = BSS.Protocol.Minimisation(steps=100)
+
+    # Create a new system using the first two molecules of 'system'.
+    # This will be an alanine-dipeptide and water in vacuum.
+    new_system = (system[0] + system[1]).toSystem()
+
+    # Run the process and check that it finishes without error.
+    assert run_process(new_system, protocol)
+
 def run_process(system, protocol):
     """Helper function to run various simulation protocols."""
 


### PR DESCRIPTION
This PR addresses issue #338 and ensures that the water topology is swapped to GROMACS format prior to writing the custom Gro87 file needed for vacuum simulations, i.e. where an infinite periodic box is added.