### PR TITLE
Add a parameter for Gromacs Process to continue simulation from the previous run. 

### DIFF
--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -131,11 +131,11 @@ class Gromacs(_process.Process):
                                             "Please install GROMACS (http://www.gromacs.org).")
 
         if not isinstance(ignore_warnings, bool):
-            raise ValueError("'ignore_warnings' must be of type 'bool.")
+            raise ValueError("'ignore_warnings' must be of type 'bool'.")
         self._ignore_warnings = ignore_warnings
 
         if not isinstance(show_errors, bool):
-            raise ValueError("'show_errors' must be of type 'bool.")
+            raise ValueError("'show_errors' must be of type 'bool'.")
         self._show_errors = show_errors
 
         # Initialise the stdout dictionary and title header.
@@ -160,8 +160,16 @@ class Gromacs(_process.Process):
         # Initialise the PLUMED interface object.
         self._plumed = None
 		
-		# Set the path of Gromacs checkpoint file
-        self._prev_cpt = prev_cpt
+		# Set the path of Gromacs checkpoint file.
+        self._prev_cpt = None
+        if prev_cpt is not None:
+            if not isinstance(prev_cpt, str):
+                raise ValueError("'prev_cpt' must be of type 'str'.")
+            else:
+                if _os.path.isfile(prev_cpt):
+                    self._prev_cpt = prev_cpt
+                else:
+                    raise IOError("Gromacs checkpoint file doesn't exist: '%s'" % prev_cpt)
 
         # Now set up the working directory for the process.
         self._setup()

--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -66,7 +66,7 @@ class Gromacs(_process.Process):
     """A class for running simulations using GROMACS."""
 
     def __init__(self, system, protocol, exe=None, name="gromacs",
-            work_dir=None, seed=None, property_map={}, ignore_warnings=False, show_errors=True):
+            work_dir=None, seed=None, property_map={}, ignore_warnings=False, show_errors=True, prev_cpt=None):
         """Constructor.
 
            Parameters
@@ -103,6 +103,9 @@ class Gromacs(_process.Process):
            show_errors : bool
                Whether to show warning/error messages when generating the binary
                run file.
+		   
+		   prev_cpt: str
+		       The checkpoint file of previous run
         """
 
         # Call the base class constructor.
@@ -156,6 +159,9 @@ class Gromacs(_process.Process):
 
         # Initialise the PLUMED interface object.
         self._plumed = None
+		
+		# Set the path of Gromacs checkpoint file
+        self._prev_cpt = prev_cpt
 
         # Now set up the working directory for the process.
         self._setup()
@@ -314,6 +320,8 @@ class Gromacs(_process.Process):
             config.append("nstlog = %d" % report_interval)      # Interval between writing to the log file.
             config.append("nstenergy = %d" % report_interval)   # Interval between writing to the energy file.
             config.append("nstxout = %d" % restart_interval)    # Interval between writing to the trajectory file.
+            if self._prev_cpt is not None:
+                config.append("continuation=yes")
             if has_box and self._has_water:
                 config.append("pbc = xyz")                      # Simulate a fully periodic box.
                 config.append("cutoff-scheme = Verlet")         # Use Verlet pair lists.
@@ -820,7 +828,12 @@ class Gromacs(_process.Process):
                   "/%s.out.mdp" % _os.path.basename(self._config_file).split(".")[0]
 
         # Use grompp to generate the portable binary run input file.
-        command = "%s grompp -f %s -po %s -c %s -p %s -r %s -o %s" \
+        if self._prev_cpt is not None:
+            command = "%s grompp -f %s -po %s -c %s -p %s -r %s -t %s -o %s" \
+            % (self._exe, self._config_file, mdp_out, self._gro_file,
+               self._top_file, self._gro_file, self._prev_cpt, self._tpr_file)
+        else:
+            command = "%s grompp -f %s -po %s -c %s -p %s -r %s -o %s" \
             % (self._exe, self._config_file, mdp_out, self._gro_file,
                self._top_file, self._gro_file, self._tpr_file)
 


### PR DESCRIPTION
Hi, This PR adds a new parameter `prev_cpt` for Gromacs Process to continue the simulation from the previous run. 

Context: 
---
I've followed the equilibration protocol (`all restrained short NVT -> backbone restrained NVT -> NVT -> heavy atom restrained  NPT -> NPT`) in [BioSimSpace Tutorial](https://github.com/michellab/BioSimSpaceTutorials/blob/main/04_fep/execution_model/scripts/BSSligprep.py) for a while, using Gromacs as MD engine, instead of  PMEMD.  But my simulation always suffered from `#WARNING SUBSAMPLING ENERGIES RESULTED IN LESS THAN 50 SAMPLES` when analyzing the result. 

As Julien suggested [here](https://github.com/michellab/Sire/issues/90#issuecomment-165442941), it means that the simulation does not start from a well-equilibrated trajectory (I've checked the overlap matrix, which seems to be reasonable). I checked my simulation and found that in the `all restrained short NVT -> backbone restrained NVT -> NVT -> heavy atom restrained  NPT -> NPT` pipeline, the temperature always starts from 0 in each step. 

In Gromacs [tutorial](http://www.mdtutorials.com/gmx/lysozyme/07_equil2.html), the NPT equilibration should be started from a thermalized system, so I added this parameter and continued the simulation from the previous step, now the subsampling warning disappeared. 

