### PR TITLE
Allow user to specify whether to use connectivity or coordinates during HMR.

### DIFF
--- a/python/BioSimSpace/Process/_gromacs.py
+++ b/python/BioSimSpace/Process/_gromacs.py
@@ -822,7 +822,6 @@ class Gromacs(_process.Process):
 
         # Add the default arguments.
         self.setArg("mdrun", True)          # Use mdrun.
-        self.setArg("-v", True)             # Verbose output.
         self.setArg("-deffnm", self._name)  # Output file prefix.
 
         # Metadynamics and steered MD arguments.

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -723,7 +723,6 @@ class Gromacs(_process.Process):
 
         # Add the default arguments.
         self.setArg("mdrun", True)          # Use mdrun.
-        self.setArg("-v", True)             # Verbose output.
         self.setArg("-deffnm", self._name)  # Output file prefix.
 
         # Metadynamics and steered MD arguments.

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -1255,7 +1255,8 @@ class Molecule(_SireWrapper):
         # Update the internal molecule object.
         self._sire_object = mol
 
-    def repartitionHydrogenMass(self, factor=4, water="no", property_map={}):
+    def repartitionHydrogenMass(self, factor=4, water="no",
+            use_coordinates=False, property_map={}):
         """Redistrubute mass of heavy atoms connected to bonded hydrogens into
            the hydrogen atoms. This allows the use of larger simulation
            integration time steps without encountering instabilities related
@@ -1272,6 +1273,12 @@ class Molecule(_SireWrapper):
                Whether to repartition masses for water molecules. Options are
                "yes", "no", and "exclusive", which can be used to repartition
                masses for water molecules only.
+
+           use_coordinates : bool
+               Whether to use the current molecular coordinates to work out
+               the connectivity before repartitioning. If False, the information
+               from the molecular topology, e.g. force field, will be used, if
+               present.
 
            property_map : dict
                A dictionary that maps system "properties" to their user defined
@@ -1306,33 +1313,40 @@ class Molecule(_SireWrapper):
             water_string = ", ".join(f"'{x}'" for x in water_options)
             raise ValueError(f"'water' must be one of: {water_string}")
 
+        if not isinstance(use_coordinates, bool):
+            raise TypeError("'use_coordinates' must be of type 'bool'.")
+
         # Check property map.
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'.")
 
+        # Update the property map to indicate that coordinates will be used
+        # to compute the connectivity.
+        pmap = property_map.copy()
+        if use_coordinates:
+            pmap["use_coordinates"] = _SireBase.wrap(True)
+
         # Handle perturbable molecules separately.
         if self.isPerturbable():
             # Repartition masses for the lambda=0 state.
-            property_map = { "mass"         : "mass0",
-                             "element"      : "element0",
-                             "connectivity" : "connectivity0",
-                             "coordinates"  : "coordinates0"
-                           }
+            pmap = { "mass"         : "mass0",
+                     "element"      : "element0",
+                     "coordinates"  : "coordinates0"
+                   }
             self._sire_object = _SireIO.repartitionHydrogenMass(
-                    self._sire_object, factor, water_options[water], property_map)
+                    self._sire_object, factor, water_options[water], pmap)
 
             # Repartition masses for the lambda=1 state.
-            property_map = { "mass"         : "mass1",
-                             "element"      : "element1",
-                             "connectivity" : "connectivity1",
-                             "coordinates"  : "coordinates1"
-                           }
+            pmap = { "mass"         : "mass1",
+                     "element"      : "element1",
+                     "coordinates"  : "coordinates1"
+                   }
             self._sire_object = _SireIO.repartitionHydrogenMass(
-                    self._sire_object, factor, water_options[water], property_map)
+                    self._sire_object, factor, water_options[water], pmap)
 
         else:
             self._sire_object = _SireIO.repartitionHydrogenMass(
-                    self._sire_object, factor, water_options[water], property_map)
+                    self._sire_object, factor, water_options[water], pmap)
 
     def _getPropertyMap0(self):
         """Generate a property map for the lambda = 0 state of the merged molecule."""

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -1255,7 +1255,8 @@ class Molecule(_SireWrapper):
         # Update the internal molecule object.
         self._sire_object = mol
 
-    def repartitionHydrogenMass(self, factor=4, water="no", property_map={}):
+    def repartitionHydrogenMass(self, factor=4, water="no",
+            use_coordinates=False, property_map={}):
         """Redistrubute mass of heavy atoms connected to bonded hydrogens into
            the hydrogen atoms. This allows the use of larger simulation
            integration time steps without encountering instabilities related
@@ -1272,6 +1273,12 @@ class Molecule(_SireWrapper):
                Whether to repartition masses for water molecules. Options are
                "yes", "no", and "exclusive", which can be used to repartition
                masses for water molecules only.
+
+           use_coordinates : bool
+               Whether to use the current molecular coordinates to work out
+               the connectivity before repartitioning. If False, the information
+               from the molecular topology, e.g. force field, will be used, if
+               present.
 
            property_map : dict
                A dictionary that maps system "properties" to their user defined
@@ -1306,33 +1313,40 @@ class Molecule(_SireWrapper):
             water_string = ", ".join(f"'{x}'" for x in water_options)
             raise ValueError(f"'water' must be one of: {water_string}")
 
+        if not isinstance(use_coordinates, bool):
+            raise TypeError("'use_coordinates' must be of type 'bool'.")
+
         # Check property map.
         if not isinstance(property_map, dict):
             raise TypeError("'property_map' must be of type 'dict'.")
 
+        # Update the property map to indicate that coordinates will be used
+        # to compute the connectivity.
+        pmap = property_map.copy()
+        if use_coordinates:
+            pmap["use_coordinates"] = _SireBase.wrap(True)
+
         # Handle perturbable molecules separately.
         if self.isPerturbable():
             # Repartition masses for the lambda=0 state.
-            property_map = { "mass"         : "mass0",
-                             "element"      : "element0",
-                             "connectivity" : "connectivity0",
-                             "coordinates"  : "coordinates0"
-                           }
+            pmap = { "mass"         : "mass0",
+                     "element"      : "element0",
+                     "coordinates"  : "coordinates0"
+                   }
             self._sire_object = _SireIO.repartitionHydrogenMass(
-                    self._sire_object, factor, water_options[water], property_map)
+                    self._sire_object, factor, water_options[water], pmap)
 
             # Repartition masses for the lambda=1 state.
-            property_map = { "mass"         : "mass1",
-                             "element"      : "element1",
-                             "connectivity" : "connectivity1",
-                             "coordinates"  : "coordinates1"
-                           }
+            pmap = { "mass"         : "mass1",
+                     "element"      : "element1",
+                     "coordinates"  : "coordinates1"
+                   }
             self._sire_object = _SireIO.repartitionHydrogenMass(
-                    self._sire_object, factor, water_options[water], property_map)
+                    self._sire_object, factor, water_options[water], pmap)
 
         else:
             self._sire_object = _SireIO.repartitionHydrogenMass(
-                    self._sire_object, factor, water_options[water], property_map)
+                    self._sire_object, factor, water_options[water], pmap)
 
     def _getPropertyMap0(self):
         """Generate a property map for the lambda = 0 state of the merged molecule."""

--- a/test/Sandpit/Exscientia/_SireWrappers/test_molecule.py
+++ b/test/Sandpit/Exscientia/_SireWrappers/test_molecule.py
@@ -78,7 +78,19 @@ def test_hydrogen_mass_repartitioning(system, ignore_waters):
             initial_mass += mass.value()
 
     # Repartition the hydrogen mass.
-    system.repartitionHydrogenMass()
+    system.repartitionHydrogenMass(factor=4)
+
+    # Work out the new mass of the system.
+    final_mass = 0
+    for molecule in system:
+        for mass in molecule._sire_object.property("mass").toVector():
+            final_mass += mass.value()
+
+    # Assert the the masses are approximately the same.
+    assert final_mass == pytest.approx(initial_mass)
+
+    # Invert the repartitioning.
+    system.repartitionHydrogenMass(factor=1/4)
 
     # Work out the new mass of the system.
     final_mass = 0

--- a/test/_SireWrappers/test_molecule.py
+++ b/test/_SireWrappers/test_molecule.py
@@ -78,7 +78,19 @@ def test_hydrogen_mass_repartitioning(system, ignore_waters):
             initial_mass += mass.value()
 
     # Repartition the hydrogen mass.
-    system.repartitionHydrogenMass()
+    system.repartitionHydrogenMass(factor=4)
+
+    # Work out the new mass of the system.
+    final_mass = 0
+    for molecule in system:
+        for mass in molecule._sire_object.property("mass").toVector():
+            final_mass += mass.value()
+
+    # Assert the the masses are approximately the same.
+    assert final_mass == pytest.approx(initial_mass)
+
+    # Invert the repartitioning.
+    system.repartitionHydrogenMass(factor=1/4)
 
     # Work out the new mass of the system.
     final_mass = 0


### PR DESCRIPTION
This PR adds an additional option, `use_coordinates`, that allows the user to specify whether to use the current molecular coordinates to compute the connectivity during hydrogen mass repartitioning. If `False`, the `connectivity` property will be used, i.e. the bonding from the topology generated by the force field.

The PR also updates the unit tests to ensure that the repartitioning is invertible.

Edits are backwards compatible, but will need the latest Sire (currently building) to ensure that the `connectivity` is used by default.

Cheers.