### PR TITLE
Set ipywidgets<8 to Avoid Issues with NGLView

### DIFF
--- a/docker/conda/recipe/template.yaml
+++ b/docker/conda/recipe/template.yaml
@@ -20,6 +20,7 @@ requirements:
     - mdtraj
     - mdanalysis
     - nglview
+    - ipywidgets<8
     - openff-toolkit-base
     - parmed
     - pydot

--- a/python/setup.py
+++ b/python/setup.py
@@ -73,6 +73,7 @@ finally:
                       "pydot",
                       "networkx",
                       "nglview",
+                      "ipywidgets<8",
                       "py3dmol",
                       "pypdb",
                       "rdkit",


### PR DESCRIPTION
Hello,

Recent changes to ipywidgets have [broken NGLView](https://github.com/nglviewer/nglview/issues/1032) - ensuring version <8 avoids any issues.

Thanks,
Finlay