### PR TITLE
Make sure ordering is preserved when a molecule is replaced

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -108,11 +108,11 @@ class Molecule(_SireWrapper):
 
     def __str__(self):
         """Return a human readable string representation of the object."""
-        return "<BioSimSpace.Molecule: nAtoms=%d, nResidues=%d>" % (self.nAtoms(), self.nResidues())
+        return "<BioSimSpace.Molecule: number=%d, nAtoms=%d, nResidues=%d>" % (self.number(), self.nAtoms(), self.nResidues())
 
     def __repr__(self):
         """Return a string showing how to instantiate the object."""
-        return "<BioSimSpace.Molecule: nAtoms=%d, nResidues=%d>" % (self.nAtoms(), self.nResidues())
+        return "<BioSimSpace.Molecule: number=%d, nAtoms=%d, nResidues=%d>" % (self.number(), self.nAtoms(), self.nResidues())
 
     def __add__(self, other):
         """Addition operator."""

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -544,22 +544,16 @@ class System(_SireWrapper):
 
         # The molecule numbers don't match.
         else:
-            # Store the original molecule number.
-            mol_num = self[index]._sire_object.number()
+            # Create a copy of the system.
+            system = self.copy()._sire_object
 
-            # Store a copy of the passed molecule.
-            mol_copy = molecule._sire_object.__deepcopy__()
+            # Update the molecule in the system, preserving the
+            # original molecular ordering.
+            system = _SireIO.updateAndPreserveOrder(
+                    system, molecule._sire_object, index)
 
-            # Delete the existing molecule.
-            self._sire_object.remove(mol_num)
-
-            # Renumber the new molecule.
-            edit_mol = mol_copy.edit()
-            edit_mol.renumber(mol_num)
-            mol_copy = edit_mol.commit()
-
-            # Add the renumbered molecule to the system.
-            self._sire_object.add(mol_copy, _SireMol.MGName("all"))
+            # Update the Sire object.
+            self._sire_object = system
 
             # Reset the index mappings.
             self._reset_mappings()

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -547,10 +547,17 @@ class System(_SireWrapper):
             # Create a copy of the system.
             system = self.copy()._sire_object
 
+            # Create a copy of the molecule.
+            molecule = molecule.copy()._sire_object
+
+            # Renumber the molecule to match the original.
+            edit_mol = molecule.edit()
+            edit_mol.renumber(self[index]._sire_object.number())
+            molecule = edit_mol.commit()
+
             # Update the molecule in the system, preserving the
             # original molecular ordering.
-            system = _SireIO.updateAndPreserveOrder(
-                    system, molecule._sire_object, index)
+            system = _SireIO.updateAndPreserveOrder(system, molecule, index)
 
             # Update the Sire object.
             self._sire_object = system
@@ -617,6 +624,8 @@ class System(_SireWrapper):
                     # original molecular ordering.
                     system = _SireIO.updateAndPreserveOrder(
                             system, mol._sire_object, idx)
+            else:
+                raise ValueError(f"System doesn't contain molecule: {mol}")
 
         # Update the Sire object.
         self._sire_object = system

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -547,17 +547,10 @@ class System(_SireWrapper):
             # Create a copy of the system.
             system = self.copy()._sire_object
 
-            # Create a copy of the molecule.
-            molecule = molecule.copy()._sire_object
-
-            # Renumber the molecule to match the original.
-            edit_mol = molecule.edit()
-            edit_mol.renumber(self[index]._sire_object.number())
-            molecule = edit_mol.commit()
-
             # Update the molecule in the system, preserving the
             # original molecular ordering.
-            system = _SireIO.updateAndPreserveOrder(system, molecule, index)
+            system = _SireIO.updateAndPreserveOrder(
+                    system, molecule._sire_object, index)
 
             # Update the Sire object.
             self._sire_object = system

--- a/python/BioSimSpace/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/_SireWrappers/_molecule.py
@@ -108,11 +108,11 @@ class Molecule(_SireWrapper):
 
     def __str__(self):
         """Return a human readable string representation of the object."""
-        return "<BioSimSpace.Molecule: nAtoms=%d, nResidues=%d>" % (self.nAtoms(), self.nResidues())
+        return "<BioSimSpace.Molecule: number=%d, nAtoms=%d, nResidues=%d>" % (self.number(), self.nAtoms(), self.nResidues())
 
     def __repr__(self):
         """Return a string showing how to instantiate the object."""
-        return "<BioSimSpace.Molecule: nAtoms=%d, nResidues=%d>" % (self.nAtoms(), self.nResidues())
+        return "<BioSimSpace.Molecule: number=%d, nAtoms=%d, nResidues=%d>" % (self.number(), self.nAtoms(), self.nResidues())
 
     def __add__(self, other):
         """Addition operator."""

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -544,22 +544,16 @@ class System(_SireWrapper):
 
         # The molecule numbers don't match.
         else:
-            # Store the original molecule number.
-            mol_num = self[index]._sire_object.number()
+            # Create a copy of the system.
+            system = self.copy()._sire_object
 
-            # Store a copy of the passed molecule.
-            mol_copy = molecule._sire_object.__deepcopy__()
+            # Update the molecule in the system, preserving the
+            # original molecular ordering.
+            system = _SireIO.updateAndPreserveOrder(
+                    system, molecule._sire_object, index)
 
-            # Delete the existing molecule.
-            self._sire_object.remove(mol_num)
-
-            # Renumber the new molecule.
-            edit_mol = mol_copy.edit()
-            edit_mol.renumber(mol_num)
-            mol_copy = edit_mol.commit()
-
-            # Add the renumbered molecule to the system.
-            self._sire_object.add(mol_copy, _SireMol.MGName("all"))
+            # Update the Sire object.
+            self._sire_object = system
 
             # Reset the index mappings.
             self._reset_mappings()

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -547,10 +547,17 @@ class System(_SireWrapper):
             # Create a copy of the system.
             system = self.copy()._sire_object
 
+            # Create a copy of the molecule.
+            molecule = molecule.copy()._sire_object
+
+            # Renumber the molecule to match the original.
+            edit_mol = molecule.edit()
+            edit_mol.renumber(self[index]._sire_object.number())
+            molecule = edit_mol.commit()
+
             # Update the molecule in the system, preserving the
             # original molecular ordering.
-            system = _SireIO.updateAndPreserveOrder(
-                    system, molecule._sire_object, index)
+            system = _SireIO.updateAndPreserveOrder(system, molecule, index)
 
             # Update the Sire object.
             self._sire_object = system
@@ -617,6 +624,8 @@ class System(_SireWrapper):
                     # original molecular ordering.
                     system = _SireIO.updateAndPreserveOrder(
                             system, mol._sire_object, idx)
+            else:
+                raise ValueError(f"System doesn't contain molecule: {mol}")
 
         # Update the Sire object.
         self._sire_object = system

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -547,17 +547,10 @@ class System(_SireWrapper):
             # Create a copy of the system.
             system = self.copy()._sire_object
 
-            # Create a copy of the molecule.
-            molecule = molecule.copy()._sire_object
-
-            # Renumber the molecule to match the original.
-            edit_mol = molecule.edit()
-            edit_mol.renumber(self[index]._sire_object.number())
-            molecule = edit_mol.commit()
-
             # Update the molecule in the system, preserving the
             # original molecular ordering.
-            system = _SireIO.updateAndPreserveOrder(system, molecule, index)
+            system = _SireIO.updateAndPreserveOrder(
+                    system, molecule._sire_object, index)
 
             # Update the Sire object.
             self._sire_object = system

--- a/test/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/test/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -239,3 +239,37 @@ def test_set_box(system):
     # Check that the angles match.
     for a0, a1 in zip(angles, expected_angles):
         assert math.isclose(a0.value(), a1.value(), rel_tol=1e-4)
+
+def test_molecule_replace(system):
+    # Make sure that molecule ordering is preserved when a molecule is
+    # replaced by another with a different MolNum.
+
+    # Extract the first molecule.
+    mol0 = system[0]
+
+    # Store the current molecule numbers.
+    mol_nums0 = system._mol_nums
+
+    # Update (replace) the first molecule with a renumbered
+    # version.
+    system.updateMolecule(0, mol0.copy())
+
+    # Get the first molecule in the updated system.
+    mol1 = system[0]
+
+    # Store the updated molecule numbers.
+    mol_nums1 = system._mol_nums
+
+    # Make sure the molecules have different numbers.
+    assert mol0.number() != mol1.number()
+
+    # Make sure the molecules have the same number of atoms and residues.
+    assert mol0.nAtoms() == mol1.nAtoms()
+    assert mol0.nResidues() == mol1.nResidues()
+
+    # Make sure that the first MolNum in the array is different.
+    assert mol_nums0[0] != mol_nums1[0]
+
+    # Make sure the rest match.
+    for num0, num1 in zip(mol_nums0[1:], mol_nums1[1:]):
+        assert num0 == num1

--- a/test/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/test/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -244,18 +244,18 @@ def test_molecule_replace(system):
     # Make sure that molecule ordering is preserved when a molecule is
     # replaced by another with a different MolNum.
 
-    # Extract the first molecule.
-    mol0 = system[0]
+    # Extract the third molecule.
+    mol0 = system[3]
 
     # Store the current molecule numbers.
     mol_nums0 = system._mol_nums
 
-    # Update (replace) the first molecule with a renumbered
+    # Update (replace) the third molecule with a renumbered
     # version.
-    system.updateMolecule(0, mol0.copy())
+    system.updateMolecule(3, mol0.copy())
 
-    # Get the first molecule in the updated system.
-    mol1 = system[0]
+    # Get the third molecule in the updated system.
+    mol1 = system[3]
 
     # Store the updated molecule numbers.
     mol_nums1 = system._mol_nums
@@ -267,9 +267,11 @@ def test_molecule_replace(system):
     assert mol0.nAtoms() == mol1.nAtoms()
     assert mol0.nResidues() == mol1.nResidues()
 
-    # Make sure that the first MolNum in the array is different.
-    assert mol_nums0[0] != mol_nums1[0]
+    # Make sure that the third MolNum in the array is different.
+    assert mol_nums0[3] != mol_nums1[3]
 
     # Make sure the rest match.
-    for num0, num1 in zip(mol_nums0[1:], mol_nums1[1:]):
+    for num0, num1 in zip(mol_nums0[0:2], mol_nums1[0:2]):
+        assert num0 == num1
+    for num0, num1 in zip(mol_nums0[4:], mol_nums1[4:]):
         assert num0 == num1

--- a/test/_SireWrappers/test_system.py
+++ b/test/_SireWrappers/test_system.py
@@ -240,3 +240,37 @@ def test_set_box(system):
     # Check that the angles match.
     for a0, a1 in zip(angles, expected_angles):
         assert math.isclose(a0.value(), a1.value(), rel_tol=1e-4)
+
+def test_molecule_replace(system):
+    # Make sure that molecule ordering is preserved when a molecule is
+    # replaced by another with a different MolNum.
+
+    # Extract the first molecule.
+    mol0 = system[0]
+
+    # Store the current molecule numbers.
+    mol_nums0 = system._mol_nums
+
+    # Update (replace) the first molecule with a renumbered
+    # version.
+    system.updateMolecule(0, mol0.copy())
+
+    # Get the first molecule in the updated system.
+    mol1 = system[0]
+
+    # Store the updated molecule numbers.
+    mol_nums1 = system._mol_nums
+
+    # Make sure the molecules have different numbers.
+    assert mol0.number() != mol1.number()
+
+    # Make sure the molecules have the same number of atoms and residues.
+    assert mol0.nAtoms() == mol1.nAtoms()
+    assert mol0.nResidues() == mol1.nResidues()
+
+    # Make sure that the first MolNum in the array is different.
+    assert mol_nums0[0] != mol_nums1[0]
+
+    # Make sure the rest match.
+    for num0, num1 in zip(mol_nums0[1:], mol_nums1[1:]):
+        assert num0 == num1

--- a/test/_SireWrappers/test_system.py
+++ b/test/_SireWrappers/test_system.py
@@ -245,18 +245,18 @@ def test_molecule_replace(system):
     # Make sure that molecule ordering is preserved when a molecule is
     # replaced by another with a different MolNum.
 
-    # Extract the first molecule.
-    mol0 = system[0]
+    # Extract the third molecule.
+    mol0 = system[3]
 
     # Store the current molecule numbers.
     mol_nums0 = system._mol_nums
 
-    # Update (replace) the first molecule with a renumbered
+    # Update (replace) the third molecule with a renumbered
     # version.
-    system.updateMolecule(0, mol0.copy())
+    system.updateMolecule(3, mol0.copy())
 
-    # Get the first molecule in the updated system.
-    mol1 = system[0]
+    # Get the third molecule in the updated system.
+    mol1 = system[3]
 
     # Store the updated molecule numbers.
     mol_nums1 = system._mol_nums
@@ -268,9 +268,11 @@ def test_molecule_replace(system):
     assert mol0.nAtoms() == mol1.nAtoms()
     assert mol0.nResidues() == mol1.nResidues()
 
-    # Make sure that the first MolNum in the array is different.
-    assert mol_nums0[0] != mol_nums1[0]
+    # Make sure that the third MolNum in the array is different.
+    assert mol_nums0[3] != mol_nums1[3]
 
     # Make sure the rest match.
-    for num0, num1 in zip(mol_nums0[1:], mol_nums1[1:]):
+    for num0, num1 in zip(mol_nums0[0:2], mol_nums1[0:2]):
+        assert num0 == num1
+    for num0, num1 in zip(mol_nums0[4:], mol_nums1[4:]):
         assert num0 == num1


### PR DESCRIPTION
This PR ensures that molecule ordering is preserved when a molecule at a given index is _replaced_ by another, i.e. by a molecule with a different `MolNum`. Previously we removed the old molecule, then added the new one, which caused a re-ordering of the underlying container, i.e. the new one would be at the end.