### PR TITLE
Fix CI issues following EXS sandpit merge

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,6 +55,9 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
 #
+      - name: Use HTTPS git
+        run: git config --global url.https://github.com/.insteadOf git@github.com:
+#
       - name: Clone the devel branch (push to devel)
         run: git clone ${{ github.repositoryUrl }}
         if: github.event_name != 'pull_request'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,11 +56,11 @@ jobs:
           use-mamba: true
 #
       - name: Clone the devel branch (push to devel)
-        run: git clone https://github.com/michellab/BioSimSpace
+        run: git clone ${{ github.repositoryUrl }}
         if: github.event_name != 'pull_request'
 #
       - name: Clone the feature branch (pull request to devel)
-        run: git clone -b ${{ github.head_ref }} --single-branch https://github.com/michellab/BioSimSpace
+        run: git clone -b ${{ github.head_ref }} --single-branch ${{ github.repositoryUrl }}
         if: github.event_name == 'pull_request'
 #
       - name: Setup Conda

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,7 +55,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
 #
-      - name: Use HTTPS git
+      - name: Use HTTPS git protocol
         run: git config --global url."https://github.com/".insteadOf 'git@github.com:'
 #
       - name: Clone the devel branch (push to devel)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -90,14 +90,14 @@ jobs:
           BUILD_DIR: ${{ github.workspace }}/build
         if: ${{ failure() }}
 #
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: build-${{ matrix.platform.name }}-${{matrix.python-version}}-${{ github.sha }}
           path: ${{ github.workspace }}/build/*/biosimspace-*.tar.bz2
           retention-days: 10
         if: ${{ success() }}
 #
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: failed-${{ matrix.platform.name }}-${{matrix.python-version}}-${{ github.sha }}
           path: ${{ github.workspace }}/build/failed.tar.bz2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
           use-mamba: true
 #
       - name: Use HTTPS git protocol
-        run: git config --global url."https://github.com/".insteadOf 'git@github.com:'
+        run: git config --global url."https://github".insteadOf git://github
 #
       - name: Clone the devel branch (push to devel)
         run: git clone ${{ github.repositoryUrl }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
           use-mamba: true
 #
       - name: Use HTTPS git
-        run: git config --global url.https://github.com/.insteadOf git@github.com:
+        run: git config --global url."https://github.com/".insteadOf 'git@github.com:'
 #
       - name: Clone the devel branch (push to devel)
         run: git clone ${{ github.repositoryUrl }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,11 +76,11 @@ jobs:
         run: mkdir ${{ github.workspace }}/build
 #
       - name: Build Conda package using mamba build
-        run: conda mambabuild --croot ${{ github.workspace }}/build -c conda-forge -c michellab ${{ github.workspace }}/BioSimSpace/recipes/biosimspace
+        run: conda mambabuild --croot ${{ github.workspace }}/build -c conda-forge -c michellab/label/dev ${{ github.workspace }}/BioSimSpace/recipes/biosimspace
         if: matrix.platform.name != 'windows' || matrix.python-version != '3.7'
 #
       - name: Build Conda package using conda build
-        run: conda build --croot ${{ github.workspace }}/build -c conda-forge -c michellab ${{ github.workspace }}/BioSimSpace/recipes/biosimspace
+        run: conda build --croot ${{ github.workspace }}/build -c conda-forge -c michellab/label/dev ${{ github.workspace }}/BioSimSpace/recipes/biosimspace
         if: matrix.platform.name == 'windows' && matrix.python-version == '3.7'
 #
       - name: Collect failed artifacts

--- a/actions/supported_force_fields.py
+++ b/actions/supported_force_fields.py
@@ -4,6 +4,6 @@
 # Import the name of all publicly exposed functions.
 from BioSimSpace.Parameters._parameters import __all__ as parameters
 
-# Sort and print separated by an literal newline character and four spaces.
+# Sort and print separated by a literal newline character and four spaces.
 parameters.sort()
 print("\\n    ".join(parameters))

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
@@ -46,7 +46,7 @@ from .._Utils import _try_import, _have_imported, _assert_imported
 
 # alchemlyb isn't available on all variants of Python that we support, so we
 # need to try_import it.
-_alchemlyb = _try_import(alchemlyb)
+_alchemlyb = _try_import("alchemlyb")
 
 if _have_imported(_alchemlyb):
     from alchemlyb.workflows import ABFE

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
@@ -42,7 +42,7 @@ import tempfile as _tempfile
 import warnings as _warnings
 import zipfile as _zipfile
 
-from ..Utils import _try_import, _have_imported, _assert_imported
+from .._Utils import _try_import, _have_imported, _assert_imported
 
 # alchemlyb isn't available on all variants of Python that we support, so we
 # need to try_import it.

--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_relative.py
@@ -42,14 +42,20 @@ import tempfile as _tempfile
 import warnings as _warnings
 import zipfile as _zipfile
 
-import alchemlyb as _alchemlyb
-from alchemlyb.workflows import ABFE
-from alchemlyb.postprocessors.units import R_kJmol as _R_kJmol
-from alchemlyb.postprocessors.units import kJ2kcal as _kJ2kcal
-from alchemlyb.preprocessing.subsampling import statistical_inefficiency as _statistical_inefficiency
-from alchemlyb.estimators import AutoMBAR as _AutoMBAR
-from alchemlyb.estimators import TI as _TI
-from alchemlyb.postprocessors.units import to_kcalmol as _to_kcalmol
+from ..Utils import _try_import, _have_imported, _assert_imported
+
+# alchemlyb isn't available on all variants of Python that we support, so we
+# need to try_import it.
+_alchemlyb = _try_import(alchemlyb)
+
+if _have_imported(_alchemlyb):
+    from alchemlyb.workflows import ABFE
+    from alchemlyb.postprocessors.units import R_kJmol as _R_kJmol
+    from alchemlyb.postprocessors.units import kJ2kcal as _kJ2kcal
+    from alchemlyb.preprocessing.subsampling import statistical_inefficiency as _statistical_inefficiency
+    from alchemlyb.estimators import AutoMBAR as _AutoMBAR
+    from alchemlyb.estimators import TI as _TI
+    from alchemlyb.postprocessors.units import to_kcalmol as _to_kcalmol
 
 import numpy as _np
 import pandas as _pd
@@ -454,6 +460,8 @@ class Relative():
                The overlap matrix. This gives the overlap between each lambda
                window.
         """
+
+        _assert_imported(_alchemlyb)
 
         if not isinstance(work_dir, str):
             raise TypeError("'work_dir' must be of type 'str'.")

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -799,7 +799,7 @@ class System(_SireWrapper):
                A container of perturbable molecule objects. The container will
                be empty if no perturbable molecules are present.
         """
-        return _Molecules(self._sire_object.search("perturbable").toGroup())
+        return _Molecules(self._sire_object.search("property is_perturbable").toGroup())
 
     def nPerturbableMolecules(self):
         """Return the number of perturbable molecules in the system.
@@ -821,13 +821,7 @@ class System(_SireWrapper):
            molecules : [:class:`Molecule <BioSimSpace._SireWrappers.Molecule>`]
                A list of decoupled molecules.
         """
-
-        molecules = []
-
-        for mol in self:
-            if mol.isDecoupled():
-                molecules.append(_Molecule(mol))
-        return molecules
+        return _Molecules(self._sire_object.search("property decouple").toGroup())
 
     def nDecoupledMolecules(self):
         """Return the number of decoupled molecules in the system.

--- a/python/BioSimSpace/_SireWrappers/_system.py
+++ b/python/BioSimSpace/_SireWrappers/_system.py
@@ -799,7 +799,7 @@ class System(_SireWrapper):
                A container of perturbable molecule objects. The container will
                be empty if no perturbable molecules are present.
         """
-        return _Molecules(self._sire_object.search("perturbable").toGroup())
+        return _Molecules(self._sire_object.search("property is_perturbable").toGroup())
 
     def nPerturbableMolecules(self):
         """Return the number of perturbable molecules in the system.

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -26,8 +26,8 @@ test:
     - SIRE_SILENT_PHONEHOME
   requires:
     - pytest
-    - ambertools
-    - gromacs
+    - ambertools  # [not win]
+    - gromacs     # [not win]
   imports:
     - BioSimSpace
   source_files:

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -26,8 +26,8 @@ test:
     - SIRE_SILENT_PHONEHOME
   requires:
     - pytest
-    - ambertools  # [not win]
-    - gromacs     # [not win]
+    - ambertools  # [linux]
+    - gromacs     # [linux]
   imports:
     - BioSimSpace
   source_files:

--- a/recipes/biosimspace/template.yaml
+++ b/recipes/biosimspace/template.yaml
@@ -26,6 +26,8 @@ test:
     - SIRE_SILENT_PHONEHOME
   requires:
     - pytest
+    - ambertools
+    - gromacs
   imports:
     - BioSimSpace
   source_files:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # BioSimSpace runtime requirements.
 
-sire ~=2023.0.0   # this matches >= 2023.0.0 && < 2023.1.0
+sire ~=2023.0.1   # this matches >= 2023.0.1 && < 2023.1.0
 
 alchemlyb ; python_version >= '3.8'
 configargparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 sire ~=2023.0.0   # this matches >= 2023.0.0 && < 2023.1.0
 
-alchemlyb
+alchemlyb ; python_version >= '3.8'
 configargparse
 kcombu_bss
 ipywidgets<8

--- a/test/Process/test_gromacs.py
+++ b/test/Process/test_gromacs.py
@@ -112,10 +112,9 @@ def run_process(system, protocol):
     # Wait for the process to end.
     process.wait()
 
-    print()
-    print(process.getProperEnergy(time_series=True))
-    print(process.getImproperEnergy(time_series=True))
-    print(process.getDihedralEnergy(time_series=True))
+    # Wait for the process to end.
+    system = process.getSystem(block=True)
+    assert system is not None
 
     # Return the process exit code.
     return not process.isError()

--- a/test/Sandpit/Exscientia/Align/test_merge.py
+++ b/test/Sandpit/Exscientia/Align/test_merge.py
@@ -2,6 +2,15 @@ import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 
+# Make sure AMBER is installed.
+if BSS._amber_home is not None:
+    exe = "%s/bin/sander" % BSS._amber_home
+    if os.path.isfile(exe):
+        has_amber = True
+    else:
+        has_amber = False
+else:
+    has_amber = False
 
 @pytest.fixture
 def perturbed_system():
@@ -12,6 +21,7 @@ def perturbed_system():
     return system
 
 
+@pytest.mark.skipif(has_amber is False, reason="Requires AMBER to be installed.")
 def test_squash(perturbed_system):
     squashed_system, mapping = BSS.Align._merge._squash(perturbed_system)
     assert len(squashed_system) == 6
@@ -21,6 +31,7 @@ def test_squash(perturbed_system):
     assert python_mapping == {0: 0, 2: 1}
 
 
+@pytest.mark.skipif(has_amber is False, reason="Requires AMBER to be installed.")
 def test_unsquash(perturbed_system):
     squashed_system, mapping = BSS.Align._merge._squash(perturbed_system)
     new_perturbed_system = BSS.Align._merge._unsquash(perturbed_system, squashed_system, mapping)

--- a/test/Sandpit/Exscientia/Align/test_merge.py
+++ b/test/Sandpit/Exscientia/Align/test_merge.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS

--- a/test/Sandpit/Exscientia/Free_Energy/test_relative.py
+++ b/test/Sandpit/Exscientia/Free_Energy/test_relative.py
@@ -4,7 +4,12 @@ import pytest
 import pandas as pd
 import numpy as np
 import bz2
-from alchemlyb.parsing.gmx import extract_u_nk
+
+try:
+    from alchemlyb.parsing.gmx import extract_u_nk
+    is_alchemlyb = True
+except ModuleNotFoundError:
+    is_alchemlyb = False
 
 try:
     from alchemtest.gmx import load_ABFE
@@ -22,6 +27,7 @@ from BioSimSpace.Sandpit.Exscientia import Types as _Types
 has_gromacs = BSS._gmx_exe is not None
 
 @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
+@pytest.mark.skipif(is_alchemlyb is False, reason="Requires alchemlyb to be installed.")
 class Test_gmx_ABFE():
     @staticmethod
     @pytest.fixture(scope='class')

--- a/test/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/test/Sandpit/Exscientia/Process/test_gromacs.py
@@ -103,7 +103,7 @@ def test_restraints(restraint):
     # Create the simulation process.
     process = BSS.Process.Gromacs(system, protocol)
 
-
+@pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
 def test_write_restraint(system, tmp_path):
     """Test if the restraint has been written in a way that could be processed
     correctly."""
@@ -143,7 +143,6 @@ def test_write_restraint(system, tmp_path):
                        work_dir=str(tmp_path))
     with open(tmp_path / 'test.top', 'r') as f:
         assert 'intermolecular_interactions' in f.read()
-
 
 def run_process(system, protocol, **kwargs):
     """Helper function to run various simulation protocols."""

--- a/test/Sandpit/Exscientia/Protocol/test_config.py
+++ b/test/Sandpit/Exscientia/Protocol/test_config.py
@@ -5,6 +5,9 @@ import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia.Protocol import FreeEnergyMinimisation
 from BioSimSpace.Sandpit.Exscientia.Align._decouple import decouple
 
+# Make sure GROMSCS is installed.
+has_gromacs = BSS._gmx_exe is not None
+
 class TestGromacsRBFE():
     @staticmethod
     @pytest.fixture(scope='class')
@@ -16,6 +19,7 @@ class TestGromacsRBFE():
         merged = BSS.Align.merge(m0, m1)
         return merged.toSystem()
 
+    @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
     def test_fep(self, system):
         '''Test if the default config writer will write the expected thing'''
         protocol = FreeEnergyMinimisation(lam=0.0,
@@ -31,6 +35,7 @@ class TestGromacsRBFE():
             assert 'fep-lambdas          = 0.00000 0.10000 0.20000 0.30000 0.40000 0.50000 0.60000 0.70000 0.80000 0.90000 1.00000' in mdp_text
             assert 'init-lambda-state = 6' in mdp_text
 
+    @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
     def test_fep_df(self, system):
         '''Test if the default config writer configured with the pd.DataFrame
         will write the expected thing.'''
@@ -47,6 +52,7 @@ class TestGromacsRBFE():
             assert 'fep-lambdas          = 0.00000 0.10000 0.20000 0.30000 0.40000 0.50000 0.60000 0.70000 0.80000 0.90000 1.00000' in mdp_text
             assert 'init-lambda-state = 6' in mdp_text
 
+    @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
     def test_staged_fep_df(self, system):
         '''Test if the multi-stage lambda will be written correctly'''
         protocol = FreeEnergyMinimisation(
@@ -82,6 +88,7 @@ class TestGromacsABFE():
                  perturbation_type="full")
         return m0, protocol
 
+    @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
     def test_decouple_vdw_q(self, system):
         m, protocol = system
         '''Test the decoupling where lambda0 = vdw-q and lambda1=none'''
@@ -94,6 +101,7 @@ class TestGromacsABFE():
             assert 'couple-lambda1 = none' in mdp_text
             assert 'couple-intramol = yes' in mdp_text
 
+    @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
     def test_annihilate_vdw2q(self, system):
         '''Test the annihilation where lambda0 = vdw-q and lambda1=none'''
         m, protocol = system
@@ -107,6 +115,7 @@ class TestGromacsABFE():
             assert 'couple-lambda1 = q' in mdp_text
             assert 'couple-intramol = no' in mdp_text
 
+    @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
     def test_sc_parameters(self, system):
         '''Test if the soft core parameters have been written.
         The default sc-alpha is 0, which means the soft-core of the vdw is not


### PR DESCRIPTION
This PR fixes some CI issues related to the recent EXS sandpit merge [here](https://github.com/michellab/BioSimSpace/pull/363):

* Recent versions of `alchemlyb` aren't available for Python 3.7. As such, we now use `_try_import` to make sure BioSimSpace can still be imported correctly.
* Tests that require `ambertools` or `gromacs` are now marked to be skipped if these aren't installed.
* The CI runner script that was introduced with the 2023 edits incorrectly pulls from michellab for _all_ pull requests, i.e. it only uses the `head_ref` for that repo. This is why the above issues weren't caught by the CI in the previous PR. I've switched to using `github.repositoryUrl`, although I'll need to test that this works (it uses the default Git protocol, not HTTPS, which hangs) in this PR. I'll try different strategies if it doesn't work.