### PR TITLE
Changed `_k_boltz` to `_k_boltz.value()` to get the underlying value …

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
@@ -343,7 +343,7 @@ class Restraint:
         """Give the free energy of removing the restraint."""
         if self._restraint_type == "boresch":
             K = (
-                _k_boltz * (_kcal_per_mol / _kelvin) / (_kj_per_mol / _kelvin)
+                _k_boltz.value() * (_kcal_per_mol / _kelvin) / (_kj_per_mol / _kelvin)
             )  # Gas constant in kJ/mol/K
             V = (
                 (_meter3 / 1000 / _mole) / _nanometer3


### PR DESCRIPTION
…of Boltzmann's

constant (in kcal mol-1 K-1) without the associated units. sire 2023.1.0 returns physical constants with their attached units.

This fixes the only test failure I see on Windows (I also see it on MacOS, and it fixes it here).

There is another test failure on MacOS arm64 and Linux aarch64 relating to kcombu_bss - this seems to give different results on ARM than X86-64. This is independent of 2023.1. I will track down what is going on...